### PR TITLE
Adding command line option to only run certain modules

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -26,6 +26,9 @@ var phantomas = function(params) {
 	// --timeout (in seconds)
 	this.timeout = (params.timeout > 0 && parseInt(params.timeout, 10)) || 15;
 
+	// --modules=localStorage,cookies
+	this.modules = (params.modules) ? params.modules.split(',') : [];
+
 	// setup the stuff
 	this.emitter = new (this.require('events').EventEmitter)();
 	this.page = require('webpage').create();
@@ -39,7 +42,7 @@ var phantomas = function(params) {
 	this.addCoreModule('requestsMonitor');
 
 	// load 3rd party modules
-	var modules = this.listModules(),
+	var modules = (this.modules.length > 0) ? this.modules : this.listModules(),
 		self = this;
 
 	modules.forEach(function(moduleName) {


### PR DESCRIPTION
I thought this would be helpful for users to be able to "opt-in" to only run certain modules. Otherwise you can disable a module by adding a line within the module code itself, but there is no way to run only certain modules. The syntax is the "--modules" flag with a comma-separated list of modules to run:

--modules=windowPerformance,domComplexity
