### PR TITLE
Issue #18: use absolute path to initialize modules

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -162,7 +162,7 @@ phantomas.prototype = {
 		this.log('Getting the list of all modules...');
 
 		var fs = require('fs'),
-			modulesDir = fs.workingDirectory + '/modules',
+			modulesDir = module.dirname + '/../modules',
 			ls = fs.list(modulesDir) || [],
 			modules = [];
 


### PR DESCRIPTION
Phantomas doesn't work correctly when executed from another directory
