### PR TITLE
Cleanup phantomas notices

### DIFF
--- a/core/modules/requestsMonitor/requestsMonitor.js
+++ b/core/modules/requestsMonitor/requestsMonitor.js
@@ -179,7 +179,7 @@ exports.module = function(phantomas) {
 									break;
 
 								default:
-									phantomas.addNotice('Unknown content type found: ' + value);
+									phantomas.log('Unknown content type found: ' + value + ' for <' + entry.url + '>');
 							}
 							break;
 

--- a/modules/ajaxRequests/ajaxRequests.js
+++ b/modules/ajaxRequests/ajaxRequests.js
@@ -8,7 +8,7 @@ exports.module = function(phantomas) {
 
 	phantomas.on('send', function(entry, res) {
 		if (entry.requestHeaders['X-Requested-With'] === 'XMLHttpRequest') {
-			phantomas.addNotice('AJAX request: ' + entry.url);
+			phantomas.log('AJAX request: ' + entry.url);
 			phantomas.incrMetric('ajaxRequests');
 		}
 	});

--- a/modules/cacheHits/cacheHits.js
+++ b/modules/cacheHits/cacheHits.js
@@ -21,7 +21,7 @@ exports.module = function(phantomas) {
 			phantomas.incrMetric(isHit ? 'cacheHits' : 'cacheMisses');
 
 			if (!isHit) {
-				phantomas.addNotice('Cache miss on ' + entry.url + ' (X-Cache: ' + header + ')');
+				phantomas.log('Cache miss: on <' + entry.url + '> (X-Cache: ' + header + ')');
 			}
 		}
 	});

--- a/modules/caching/caching.js
+++ b/modules/caching/caching.js
@@ -50,15 +50,15 @@ exports.module = function(phantomas) {
 		// static assets
 		if (entry.isImage || entry.isJS || entry.isCSS) {
 			if (ttl === false) {
-				phantomas.addNotice("No caching specified for <" + entry.url + ">");
+				phantomas.log("Caching: no caching specified for <" + entry.url + ">");
 				phantomas.incrMetric('cachingNotSpecified');
 			}
 			else if (ttl === 0) {
-				phantomas.addNotice("Caching disabled for <" + entry.url + ">");
+				phantomas.log("Caching: disabled for <" + entry.url + ">");
 				phantomas.incrMetric('cachingDisabled');
 			}
 			else if (ttl < 7 * 86400) {
-				phantomas.addNotice("Caching period is less than a week for <" + entry.url + "> (set to " + ttl + " s)");
+				phantomas.log("Caching: caching period is less than a week for <" + entry.url + "> (set to " + ttl + " s)");
 				phantomas.incrMetric('cachingTooShort');
 			}
 		}

--- a/modules/staticAssets/staticAssets.js
+++ b/modules/staticAssets/staticAssets.js
@@ -21,7 +21,7 @@ exports.module = function(phantomas) {
 		// check for query string -> foo.css?123
 		if (entry.isImage || entry.isJS || entry.isCSS) {
 			if (entry.url.indexOf('?') > -1) {
-				phantomas.addNotice('<' + entry.url + '> (' + entry.type.toUpperCase() + ') served with query string');
+				phantomas.log('Query string: <' + entry.url + '> (' + entry.type.toUpperCase() + ') served with query string');
 				phantomas.incrMetric('assetsWithQueryString');
 			}
 		}
@@ -29,7 +29,7 @@ exports.module = function(phantomas) {
 		// check for not-gzipped CSS / JS / HTML files
 		if (entry.isJS || entry.isCSS || entry.isHTML) {
 			if (!entry.gzip && isContent) {
-				phantomas.addNotice('<' + entry.url + '> (' + entry.type.toUpperCase() + ') served without compression');
+				phantomas.log('GZIP: <' + entry.url + '> (' + entry.type.toUpperCase() + ') served without compression');
 				phantomas.incrMetric('assetsNotGzipped');
 			}
 		}
@@ -37,7 +37,7 @@ exports.module = function(phantomas) {
 		// check small images that can be base64 encoded
 		if (entry.isImage) {
 			if (entry.bodySize < BASE64_SIZE_THRESHOLD) {
-				phantomas.addNotice('<' + entry.url + '> (' + (entry.bodySize/1024).toFixed(2) + ' kB) should be served as base64 encoded');
+				phantomas.log('base64: <' + entry.url + '> (' + (entry.bodySize/1024).toFixed(2) + ' kB) should be considered to be served base64-encoded');
 				phantomas.incrMetric('smallImages');
 			}
 		}


### PR DESCRIPTION
Move most the notices to the log available via:
- console when in `-verbose` mode
- log file when `-log` is provided
