### PR TITLE
domQueries: module cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ phantomas metrics for <https://github.com/macbre/phantomas>:
 * httpTrafficCompleted: 2521
 * domains: 6
 * DOMqueries: 58
-* DOMinserts: 17
-* jQuerySelectors: 0
-* jQueryOnDOMReadyFunctions: 0
+* DOMqueriesById: 16
+* DOMqueriesByClassName: 42
+* DOMinserts: 18
 * eventsBound: 113
 * cookiesSent: 0
 * cookiesRecv: 434
@@ -252,9 +252,9 @@ _Metrics are calculated based on ``X-Cache`` header added by Varnish  / Squid se
 ### DOM queries
 
 * DOMqueries: number of `document.getElementById` and `document.getElementsByClassName` calls
+* DOMqueriesById: number of `document.getElementById` calls
+* DOMqueriesByClassName: number of `document.getElementsByClassName` calls
 * DOMinserts: number of DOM nodes inserts
-* jQuerySelectors: number of jQuery selectors calls (e.g. `$('#foo > .bar')`)
-* jQueryOnDOMReadyFunctions: number of functions bound to onDOMready event
 
 ### Event listeners
 

--- a/modules/domQueries/domQueries.js
+++ b/modules/domQueries/domQueries.js
@@ -1,39 +1,31 @@
 /**
  * Analyzes DOM queries done via native DOM methods & jQuery
  */
-exports.version = '0.3';
+exports.version = '0.4';
 
 exports.module = function(phantomas) {
         phantomas.setMetric('DOMqueries');
+        phantomas.setMetric('DOMqueriesById');
+        phantomas.setMetric('DOMqueriesByClassName');
         phantomas.setMetric('DOMinserts');
-        phantomas.setMetric('jQuerySelectors');
-        phantomas.setMetric('jQueryOnDOMReadyFunctions');
 
 	// fake native DOM functions
 	phantomas.once('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
-				// metrics storage
-				phantomas.set('DOMqueries', 0);
-				phantomas.set('DOMinserts', 0);
-				//phantomas.domInsertsBacktrace = [];
-
-				//phantomas.set('jQueryOnDOMReadyFunctions', 0);
-				//phantomas.jQueryOnDOMReadyFunctionsBacktrace = [];
-	
-				//phantomas.set('jQuerySelectors', 0);
-				//phantomas.jQuerySelectorsBacktrace = [];
-
 				// count DOM queries by either ID or class name
 				var querySpy = function(query) {
 					phantomas.log('DOM query: "' + query + '"');
-					phantomas.incr('DOMqueries');
+					phantomas.incrMetric('DOMqueries');
 				};
 
 				phantomas.spy(window.document, 'getElementById', function(id) {
+					phantomas.incrMetric('DOMqueriesById');
 					querySpy('#' + id);
 				});
+
 				phantomas.spy(window.document, 'getElementsByClassName', function(className) {
+					phantomas.incrMetric('DOMqueriesByClassName');
 					querySpy('.' + className);
 				});
 
@@ -46,78 +38,13 @@ exports.module = function(phantomas) {
 						return;
 					}
 
-					phantomas.incr('DOMinserts');
+					phantomas.incrMetric('DOMinserts');
 					phantomas.log('DOM insert: node "' + phantomas.getDOMPath(child) + '" added to "' + phantomas.getDOMPath(this) + '"');
-					/**
-					var caller = phantomas.getCaller();
-					phantomas.domInsertsBacktrace.push({
-						url: caller.sourceURL,
-						line: caller.line
-					});
-					**/
 				};
 
 				phantomas.spy(Node.prototype, 'appendChild', appendSpy);
 				phantomas.spy(Node.prototype, 'insertBefore', appendSpy);
-
-				/**
-				// hook into $.fn.init to catch DOM queries
-				// 
-				// TODO: use a better approach here:
-				// @see https://github.com/osteele/jquery-profile
-				var jQuery;
-		
-				window.__defineSetter__('jQuery', function(val) {
-					jQuery = val;
-					console.log('Mocked jQuery v' + val.fn.jquery + ' object');
-				});
-
-				window.__defineGetter__('jQuery', function() {
-					return jQuery;
-				});
-				**/
 			})(window.__phantomas);
 		});
-	});
-
-	phantomas.on('report', function() {
-		phantomas.setMetricFromScope('DOMqueries');
-		phantomas.setMetricFromScope('DOMinserts');
-/**
-		phantomas.setMetricFromScope('jQuerySelectors');
-		phantomas.setMetricFromScope('jQueryOnDOMReadyFunctions');
-
-		// list all selectors
-		var selectorsBacktrace = phantomas.evaluate(function() {
-			return window.__phantomas.jQuerySelectorsBacktrace;
-		});
-		phantomas.addNotice('jQuery selectors:');
-		selectorsBacktrace.forEach(function(item) {
-			phantomas.addNotice('* $("' + item.selector + '") called from ' + item.url + ' @ ' + item.line);
-		});
-		phantomas.addNotice();
-
-		// list all onDOMReady functions
-		var onDOMReadyBacktrace = phantomas.evaluate(function() {
-			return window.__phantomas.jQueryOnDOMReadyFunctionsBacktrace;
-		});
-
-		phantomas.addNotice('jQuery onDOMReady functions (' + onDOMReadyBacktrace.length + '):');
-		onDOMReadyBacktrace.forEach(function(item) {
-			phantomas.addNotice('* bound from ' + item.url + ' @ ' + item.line);
-		});
-		phantomas.addNotice();
-
-		// list all DOM inserts
-		var domInsertsBacktrace = phantomas.evaluate(function() {
-			return window.__phantomas.domInsertsBacktrace;
-		});
-
-		phantomas.addNotice('DOM inserts (' + domInsertsBacktrace.length + '):');
-		domInsertsBacktrace.forEach(function(item) {
-			phantomas.addNotice('* from ' + item.url + ' @ ' + item.line);
-		});
-		phantomas.addNotice();
-**/
 	});
 };


### PR DESCRIPTION
- add `DOMqueriesById` and `DOMqueriesByClassName` metrics
- remove jQuery related metrics (will be moved to a separate module)
- remove commented out code
