### PR TITLE
jQuery: add jQuerySizzleCalls metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This helper script requires NodeJS.
 
 ## Metrics
 
-_Current number of metrics: 77_
+_Current number of metrics: 78_
 
 Units:
 
@@ -137,7 +137,8 @@ phantomas metrics for <https://github.com/macbre/phantomas>:
 * headersSentSize: 1591
 * headersRecvSize: 5886
 * jQueryVersion: 2.0.0
-* jQueryOnDOMReadyFunctions: 40
+* jQueryOnDOMReadyFunctions: 41
+* jQuerySizzleCalls: 90
 * assetsNotGzipped: 1
 * assetsWithQueryString: 3
 * smallImages: 2
@@ -288,6 +289,7 @@ _Metrics are calculated based on ``X-Cache`` header added by Varnish  / Squid se
 
 * jQueryVersion: version of jQuery framework (if loaded)
 * jQueryOnDOMReadyFunctions: number of functions bound to onDOMReady event
+* jQuerySizzleCalls: number of calls to [Sizzle](http://sizzlejs.com/) (including those that will be resolved using ``querySelectorAll``)
 
 ### Static assets
 

--- a/modules/jQuery/jQuery.js
+++ b/modules/jQuery/jQuery.js
@@ -1,33 +1,23 @@
 /**
  * Analyzes jQuery activity
+ *
+ * @see http://code.jquery.com/jquery-1.10.2.js
+ * @see http://code.jquery.com/jquery-2.0.3.js
  */
-exports.version = '0.1';
+exports.version = '0.2';
 
 exports.module = function(phantomas) {
         phantomas.setMetric('jQueryVersion', '');
-        //phantomas.setMetric('jQuerySelectors');
         phantomas.setMetric('jQueryOnDOMReadyFunctions');
+        phantomas.setMetric('jQuerySizzleCalls');
 
-	// fake native DOM functions
+	// spy calls to jQuery functions
 	phantomas.once('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
-				// hook into $.fn.init to catch DOM queries
-				/**
-				var jQueryPolling = setInterval(function() {
-					if (typeof window.jQuery !== 'undefined') {
-						phantomas.log('jQuery: loaded v' + window.jQuery.fn.jquery);
-
-						phantomas.spy(window.jQuery.fn, 'init', function(selector, context, rootjQuery) {
-							phantomas.log('jQuery called ' + (typeof selector));
-						});
-
-						clearInterval(jQueryPolling);
-					}
-				}, 50);
-				**/
 				var jQuery;
 
+				// TODO: create a helper - phantomas.spyGlobalVar() ?
 				window.__defineSetter__('jQuery', function(val) {
 					var version = val.fn.jquery;
 					jQuery = val;
@@ -39,6 +29,12 @@ exports.module = function(phantomas) {
 					phantomas.spy(val.ready, 'promise', function() {
 						phantomas.log('jQuery.ready called: from ' + phantomas.getCaller(3));
 						phantomas.incrMetric('jQueryOnDOMReadyFunctions');
+					});
+
+					// Sizzle calls - jQuery.find
+					phantomas.spy(val, 'find', function(selector, context) {
+						phantomas.log('Sizzle called: ' + selector + ' (context: ' + phantomas.getDOMPath(context) + ')');
+						phantomas.incrMetric('jQuerySizzleCalls');
 					});
 				});
 


### PR DESCRIPTION
Please note that (due to the use closures in jQuery code) this metric includes Sizzle calls that will be resolved using `document.querySelectorAll()`
