### PR TITLE
jQuery module causes PhantomJS crash with old jQuery versions

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -129,7 +129,7 @@
 		function spy(obj, fn, callback) {
 			var origFn = obj[fn];
 
-			if (typeof origFn !== 'function') {
+			if (typeof origFn !== 'function' || typeof origFn !== 'object') {
 				return false;
 			}
 


### PR DESCRIPTION
Typechecking added in 0.6.1 seemed to create additional PhantomJS
crashes in some cases.

Adding an additional typecheck for object seems to prevent those
crashs, but I don't know if it interferes with functionality.
