### PR TITLE
FE-BE Stat Numbers Accuracy

### DIFF
--- a/core/modules/requestsMonitor/requestsMonitor.js
+++ b/core/modules/requestsMonitor/requestsMonitor.js
@@ -237,11 +237,15 @@ exports.module = function(phantomas) {
 	});
 
 	// TTFB / TTLB metrics
+	var ttfbMeasured = false;
+
 	phantomas.on('recv', function(entry, res) {
-		// check the first request
-		if (entry.id === 1) {
+		// check the first response which is not a redirect (issue #74)
+		if (!ttfbMeasured && !entry.isRedirect) {
 			phantomas.setMetric('timeToFirstByte', entry.timeToFirstByte);
 			phantomas.setMetric('timeToLastByte', entry.timeToLastByte);
+
+			ttfbMeasured = true;
 		}
 
 		// completion of the last HTTP request


### PR DESCRIPTION
I'm not sure how this is supposed to work, but I'm curious as to know whether you've noticed any discrepancies. 

I've noticed a number of times where the stats are completely blown out, as in:

```
Time spent on backend / frontend: 0% / 100%
```

and I'm not sure if everything is behaving as intended.
