### PR TITLE
Minor improvements

### DIFF
--- a/test/modules/mock.js
+++ b/test/modules/mock.js
@@ -111,7 +111,6 @@ phantomas.prototype = {
 	echo: noop,
 	evaluate: noop,
 	injectJs: noop,
-	getPageContent: noop,
 	median: noop,
 };
 

--- a/test/public-api-test.js
+++ b/test/public-api-test.js
@@ -17,7 +17,12 @@ mockery.registerMock('system', {
 	os: {}
 });
 mockery.registerMock('webpage', {
-	create: function() {}
+	create: function() {
+		return {
+			evaluate: function() {},
+			injectJs: function() {}
+		};
+	},
 });
 mockery.enable({
 	warnOnUnregistered: false
@@ -58,7 +63,6 @@ vows.describe('phantomas public API').addBatch({
 				'evaluate',
 				'injectJs',
 				'require',
-				'getPageContent',
 				'median'
 			];
 


### PR DESCRIPTION
- support [messages formatting](https://developer.mozilla.org/en-US/docs/Web/API/console?redirectlocale=en-US&redirectslug=DOM%2Fconsole#Using_string_substitutions) in `phantomas.log`
- use `Function.bind` (add a polyfill)
- remove `phantomas.getPageContent` helper
