### PR TITLE
Updating to use Phapper over Phantomjs NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "phapper": "~0.1.4"
+    "phapper": "~0.1.7",
     "ansicolors": "0.2",
     "ansistyles": "0.1",
     "commander": "2.0",


### PR DESCRIPTION
> @macbre If you're not interested, I understand. Simply close the PR. :)
##### Why Phapper:
1. Phapper more cleanly supports using existing installations of PhantomJS, allowing for users to have a global install, saving time in installing the module.
2. Phapper supports running PhantomJS script Synchronously, which has it benefits when running a large number of processes through it. Ideally, `rum-multiple.js` would be updated to run synchronously to avoid errors due to process limitations (which I've seen when running a large number of tests).
##### Downside to Phapper (over Phantomjs NPM):

Phapper doesn't currently support PhantomJS installation on Windows. However, it should work with custom PhantomJS installations (although I don't have a Window machines accessible to verify).
