### PR TITLE
Stricter checks to prevent #156

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -224,7 +224,7 @@
 				entry += '#' + node.id;
 			}
 			// div#foo.bar.test
-			else if (node.className && node.className !== '') {
+			else if (typeof node.className === 'string' && node.className !== '') {
 				entry += '.' + node.className.trim().replace(/ +/g, '.');
 			}
 

--- a/modules/domComplexity/domComplexity.js
+++ b/modules/domComplexity/domComplexity.js
@@ -37,11 +37,19 @@ exports.module = function(phantomas) {
 							}
 
 							// @see https://developer.mozilla.org/en/DOM%3awindow.getComputedStyle
-							var styles = window.getComputedStyle(node);
+							var styles = window.getComputedStyle(node),
+								size = 0;
 
 							if (styles && styles.getPropertyValue('display') === 'none') {
-								//console.log(node.innerHTML);
-								phantomas.incr('hiddenContentSize', node.innerHTML.length);
+								if (typeof node.innerHTML === 'string') {
+									size = node.innerHTML.length;
+									phantomas.incr('hiddenContentSize', size);
+
+									// log hidden containers bigger than 1 kB
+									if (size > 1024) {
+										phantomas.log('Hidden content: ' + phantomas.getDOMPath(node) + ' (' + size + ' bytes)');
+									}
+								}
 
 								// don't run for child nodes as they're hidden as well
 								return false;


### PR DESCRIPTION
- fixes #156
- log content hidden via CSS bigger than 1 kB

```
22:42:15.811 Hidden content: body > div.wrapper > div.site.clearfix > div#site-container > div.container > div.columns.profilecols.js-username > div.column-main > div.tab-content.js-repo-filter > div.contributions-tab > div#contribution-activity > div.period-filter.clearfix > div.select-menu.js-menu-container.js-select-menu.js-period-container > div.select-menu-modal-holder.js-menu-content.js-navigation-container (1817 bytes)
```
