### PR TITLE
add Graphite formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ phantomas --url https://github.com/macbre/phantomas --verbose --no-externals --a
 #### Parameters
 
 * `--url` URL of the page to generate metrics for (required)
-* `--format=[json|csv|tap|plain]` output format (``plain`` is the default one)
+* `--format=[json|csv|tap|graphite|plain]` output format (``plain`` is the default one)
 * `--timeout=[seconds]` timeout for phantomas run (defaults to 15 seconds)
 * `--viewport=[width]x[height]` phantomJS viewport dimensions (1280x1024 is the default)
 * `--verbose` writes debug messages to the console

--- a/core/formatters/graphite.js
+++ b/core/formatters/graphite.js
@@ -1,0 +1,40 @@
+/**
+ * Results formatter for --format=graphite
+ * Use with ./phantomas --url <yoururl.com> --format graphite | nc <yourgraphitehost.org> <graphiteport>
+ * ex : ./phantomas --url http://www.google.com --format graphite | nc mygraphite.org 2003
+ *
+ * if "stats_counts.phantomas" doesn't fit your needs, just replace it :
+ * Use with ./phantomas --url <yoururl.com> --format graphite | replace "stats_counts.phantomas" "whatuwant" | nc <yourgraphitehost.org> <graphiteport>
+ */
+var fold = require('travis-fold');
+
+module.exports = function(results) {
+	// public API
+	return {
+		render: function() {
+			var res = [],
+				timestamp = Math.round(new Date().getTime() / 1000);
+
+			//clean the url
+			var cleanUrl = results.getUrl().replace(/http\:\/\/www?\./,'').replace(/\/$/,'').replace(/\W/g,'-');
+
+			// metrics
+			fold.pushStart(res, 'metrics');
+
+			results.getMetricsNames().forEach(function(metric) {
+				var line = 'stats_counts.phantomas.' + cleanUrl + '.' + metric + ' ' + results.getMetric(metric) + ' ' + timestamp;
+
+				res.push(line);
+			});
+
+			fold.pushEnd(res, 'metrics');
+			res.push('');
+
+
+			return fold.wrap(
+				results.getUrl(),
+				res.join('\n').trim()
+			);
+		}
+	};
+};


### PR DESCRIPTION
Hi,

This PR allow to use Phantomas to easily export results into [Graphite backend](http://graphite.wikidot.com/).

```
./phantomas --url http://www.google.com --format graphite | nc mygraphite.org 2003
```

will generate a graphite node : `stats_counts.phantomas.google-com.<metricsname>` for each metrics computed by Phantomas.

You could then add a cron job for your website to do this every 10 minutes for exemple, in order to have an impressive dashboard for Synthetic User Monitoring made by Phantomas, like this :

![webperf_phantomas_-_graphite_dashboard](https://f.cloud.github.com/assets/1484406/1850995/6f2f5d9a-76e0-11e3-9914-527e062b1597.png)

Thanks.
