### PR TITLE
run-multiple.js cannot find phantomas.js

### DIFF
--- a/run-multiple.js
+++ b/run-multiple.js
@@ -40,7 +40,7 @@ var url = params.url,
 function runPhantomas(params, callback) {
 	var timeMs = Date.now(),
 		cmd = [
-			'phantomas',
+			__dirname + '/bin/phantomas.js',
 			'--format json',
 			'--url "' + params.url + '"'
 		];


### PR DESCRIPTION
I used a fresh clone of Phantomas and saw the following error when executing run-multiple.js:

``` bash
chris [~/src/phantomas] (master)  $ ./run-multiple.js --url=http://example.com --runs=5
phantomas v0.12.1 / PhantomJS v1.9.7 / nodejs v0.10.26
Performing 5 run(s) for <http://example.com>...
Remaining runs: 5
Error from phantomas: /bin/sh: /Users/chris/src/phantomas/phantomas.js: No such file or directory
```

I noticed that run-multiple.js was last edited (7a1e0fc) about two days before the file it depends on was moved to another folder (68d122f)

This PR might not fix the problem correctly, but it got me back up and running quickly so I wanted to share it.

This project is amazing, thank you for the awesome tool!
