### PR TITLE
Pass envirnoment variables when running PhantomJS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ function phantomas(url, options, callback) {
 		path = '',
 		proc,
 		spawnOptions = {
-			env: {}
+			env: process.env
 		},
 		data = '';
 


### PR DESCRIPTION
Fixes /usr/bin/env: node: No such file or directory

Regression introduced by b070626b

A proper fix for #246
