### PR TITLE
fix: add timeToLastByte to onLoad and onContentLoad metrics

### DIFF
--- a/modules/har/har.js
+++ b/modules/har/har.js
@@ -129,8 +129,8 @@ function createHAR(page, creator) {
                     id: address,
                     title: title,
                     pageTimings: {
-                        onLoad: page.windowOnLoadTime || -1,
-                        onContentLoad: page.onDOMReadyTime || -1
+                        onLoad: page.onLoad || -1,
+                        onContentLoad: page.onContentLoad || -1
                     }
                 }
             ],
@@ -153,7 +153,10 @@ exports.module = function(phantomas) {
         startTime: undefined,
         endTime: undefined,
         onDOMReadyTime: undefined,
-        windowOnLoadTime: undefined
+        windowOnLoadTime: undefined,
+        timeToLastByte: undefined,
+        onLoad: undefined,
+        onContentLoad: undefined
     };
 
     var creator = {
@@ -217,6 +220,9 @@ exports.module = function(phantomas) {
             case 'windowOnLoadTime':
                 page.windowOnLoadTime = value;
                 break;
+            case 'timeToLastByte':
+                page.timeToLastByte = value;
+                break;
         }
     });
 
@@ -231,6 +237,11 @@ exports.module = function(phantomas) {
 
         page.address = page.origin.url;
         page.title = page.origin.title;
+
+        // Times (windowOnLoadTime, onDOMReadyTime) are relative to responseEnd entry
+        // in NavigationTiming (represented by timeToLastByte metric)
+        page.onLoad = page.timeToLastByte + page.windowOnLoadTime;
+        page.onContentLoad = page.timeToLastByte + page.onDOMReadyTime;
 
         phantomas.log('Create HAR: %s ("%s")', page.address, page.title);
 


### PR DESCRIPTION
From the spec:

```
* onContentLoad [number, optional] - Content of the page loaded. Number of milliseconds since page load started (page.startedDateTime). Use -1 if the timing does not apply to the current request.
* onLoad [number,optional] - Page is loaded (onLoad event fired). Number of milliseconds since page load started (page.startedDateTime). Use -1 if the timing does not apply to the current request.
```

From Phantomas:
`Times (windowOnLoadTime, onDOMReadyTime) are relative to responseEnd entry in NavigationTiming (represented by timeToLastByte metric)`

I've added `timeToLastByte` to `windowOnLoadTime` and `onDOMReadyTime` metrics.
I'm not sure if my fix is correct, what do you think ?
