### PR TITLE
errStream: fix a memory leak

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var debug = require('debug')('phantomas'),
 	Engines = require('./engines'),
 	path = require('path'),
 	Q = require('q'),
+	Stream = require('stream'),
 	VERSION = require('./../package').version;
 
 function phantomas(url, options, callback) {
@@ -48,8 +49,10 @@ function phantomas(url, options, callback) {
 	ipc.setEventEmitter(events);
 
 	// pipe log messages to error stream
-	var errStream = new (require('stream').Readable)();
-	errStream.on('error', function() {});
+	var errStream = new Stream.Readable();
+	errStream._read = function() {
+		return true;
+	};
 
 	ipc.on('log', function(msg) {
 		errStream.push(msg + "\n");
@@ -111,6 +114,9 @@ function phantomas(url, options, callback) {
 			debug('Error when parsing JSON (%s)', ex);
 			errStream.push(data);
 		}
+
+		// finish the readable stream
+		errStream.emit('end');
 
 		if (json !== false) {
 			events.emit('data', json);


### PR DESCRIPTION
Close the stream properly by emitting an 'end' event

Resolves #348 
