### PR TITLE
Check if stderr is a TTY for colors (not stdout)

### DIFF
--- a/bin/phantomas.js
+++ b/bin/phantomas.js
@@ -129,7 +129,7 @@ if (options.progress === true) {
 
 // add env variable to turn off ANSI colors when needed (#237)
 // suppress this behaviour by passing --colors option (issue #342)
-if (!process.stdout.isTTY && (options.colors !== true)) {
+if (!process.stderr.isTTY && (options.colors !== true)) {
 	debug('ANSI colors turned off');
 	process.env.BW = 1;
 }


### PR DESCRIPTION
Assume I were to run the following:

```
phantomas http://justinetunney.com --reporter=json | pretty-json >report.json
```

In this case, stderr would be a terminal (since I used `|` instead of `|&`) but stdout would not. Since logging is sent to stderr, one would assume it would continue to have ANSI colors. But this is not the case, because the code incorrectly tests the stdout file descriptor, rather than stderr.

This patch should makes things better for you guys. Please confirm that your project never emits ANSI colors to stdout before merging. Thanks in advance.
