### PR TITLE
analyze-css: use v0.8.0

### DIFF
--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -92,6 +92,13 @@
       "unit": "number",
       "module": "analyzeCss"
     },
+    "redundantChildNodesSelectors": {
+      "desc": "number of redundant child nodes selectors",
+      "optional": true,
+      "offenders": true,
+      "unit": "number",
+      "module": "analyzeCss"
+    },
     "cssComments": {
       "desc": "number of comments in CSS source",
       "optional": true,
@@ -112,8 +119,22 @@
       "unit": "number",
       "module": "analyzeCss"
     },
+    "cssComplexSelectorsByAttribute": {
+      "desc": "number of selectors with complex matching by attribute (e.g. )",
+      "optional": true,
+      "offenders": true,
+      "unit": "class$=\"foo\"",
+      "module": "analyzeCss"
+    },
     "cssDuplicatedSelectors": {
       "desc": "number of CSS selectors defined more than once in CSS source",
+      "optional": true,
+      "offenders": true,
+      "unit": "number",
+      "module": "analyzeCss"
+    },
+    "cssDuplicatedProperties": {
+      "desc": "number of CSS property definitions duplicated within a selector",
       "optional": true,
       "offenders": true,
       "unit": "number",
@@ -135,6 +156,13 @@
     },
     "cssOldIEFixes": {
       "desc": "number of fixes for old versions of Internet Explorer (e.g. * html .foo {} and .foo { *zoom: 1 })",
+      "optional": true,
+      "offenders": true,
+      "unit": "number",
+      "module": "analyzeCss"
+    },
+    "cssImports": {
+      "desc": "number of @import rules",
       "optional": true,
       "offenders": true,
       "unit": "number",
@@ -848,7 +876,7 @@
       "module": "windowPerformance"
     }
   },
-  "metricsCount": 144,
+  "metricsCount": 148,
   "modulesCount": 30,
   "version": "1.6.0"
 }

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -7,13 +7,17 @@
  *
  * setMetric('cssBase64Length') @desc total length of base64-encoded data in CSS source (will warn about base64-encoded data bigger than 4 kB) @optional @offenders
  * setMetric('cssRedundantBodySelectors') @desc number of redundant body selectors (e.g. body .foo, section body h2, but not body > h1) @optional @offenders
+ * setMetric('redundantChildNodesSelectors') @desc number of redundant child nodes selectors @optional @offenders
  * setMetric('cssComments') @desc number of comments in CSS source @optional @offenders
  * setMetric('cssCommentsLength') @desc length of comments content in CSS source @optional
  * setMetric('cssComplexSelectors') @desc number of complex selectors (consisting of more than three expressions, e.g. header ul li .foo) @optional @offenders
+ * setMetric('cssComplexSelectorsByAttribute') @desc  number of selectors with complex matching by attribute (e.g. [class$="foo"]) @optional @offenders
  * setMetric('cssDuplicatedSelectors') @desc number of CSS selectors defined more than once in CSS source @optional @offenders
+ * setMetric('cssDuplicatedProperties') @desc number of CSS property definitions duplicated within a selector @optional @offenders
  * setMetric('cssEmptyRules') @desc number of rules with no properties (e.g. .foo { }) @optional @offenders
  * setMetric('cssExpressions') @desc number of rules with CSS expressions (e.g. expression( document.body.clientWidth > 600 ? "600px" : "auto" )) @optional @offenders
  * setMetric('cssOldIEFixes') @desc number of fixes for old versions of Internet Explorer (e.g. * html .foo {} and .foo { *zoom: 1 }) @optional @offenders
+ * setMetric('cssImports') @desc number of @import rules @optional @offenders
  * setMetric('cssImportants') @desc number of properties with value forced by !important @optional @offenders
  * setMetric('cssMediaQueries') @desc number of media queries (e.g. @media screen and (min-width: 1370px)) @optional @offenders
  * setMetric('cssOldPropertyPrefixes') @desc number of properties with no longer needed vendor prefix, powered by data provided by autoprefixer (e.g. --moz-border-radius) @optional @offenders

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "analyze-css": "0.7.x",
+    "analyze-css": "0.8.x",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.0",
     "ascii-table": "0.0.4",


### PR DESCRIPTION
Add `cssDuplicatedProperties` and `redundantChildNodesSelectors` metrics.
