### PR TITLE
ssl-protocol: use "any" by default (instead of sslv3)

### DIFF
--- a/bin/phantomas.js
+++ b/bin/phantomas.js
@@ -41,7 +41,7 @@ program
 	.describe('colors', 'forces ANSI colors even when output is piped').boolean('colors')
 	.describe('disable-js', 'disable JavaScript on the page that will be loaded').boolean('disable-js')
 	.describe('ignore-ssl-errors', 'ignores SSL errors, such as expired or self-signed certificate errors')
-	.describe('ssl-protocol', 'sets the SSL protocol for secure connections [sslv3|sslv2|tlsv1|any]')
+	.describe('ssl-protocol', 'sets the SSL protocol for secure connections [sslv3|sslv2|tlsv1|any]').default('ssl-protocol', 'any')
 	.describe('log', 'log to a given file')
 	.describe('modules', 'run selected modules only [moduleOne],[moduleTwo],...')
 	.describe('include-dirs', 'load modules from specified directories [dirOne],[dirTwo],...')

--- a/lib/engines/gecko.js
+++ b/lib/engines/gecko.js
@@ -24,6 +24,12 @@ module.exports = {
 		// SlimerJS binary
 		args.push(path);
 
+		// filter out --ssl-protocol option
+		// supoorted by PhantomJS, but not by SlimerJS
+		engineArgs = engineArgs.filter(function(opt) {
+			return (opt.indexOf('--ssl-protocol=') === 0) ? false /* remove */ : true;
+		});
+
 		// pass runner and phantomas options
 		args = args.concat(engineArgs);
 


### PR DESCRIPTION
Improves #411
