### PR TITLE
Provide error message when a CSS is empty

### DIFF
--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -79,6 +79,8 @@ exports.module = function(phantomas) {
 					var offender = entry.url;
 					if (err.indexOf('CSS parsing failed') > 0) {
 						offender += ' (' + err.trim() + ')';
+					} else if (err.indexOf('Empty CSS was provided') > 0 ) {
+						offender += ' (Empty CSS was provided)';
 					}
 
 					phantomas.incrMetric('cssParsingErrors');


### PR DESCRIPTION
Example on this page: http://molovo.co/
Phantomas says there are three files with parsing errors. Two of them are just empty files.
