### PR TITLE
Parse date in 'expires' header where supplied - fixes #468

### DIFF
--- a/modules/caching/caching.js
+++ b/modules/caching/caching.js
@@ -13,7 +13,9 @@ exports.module = function(phantomas) {
 	function getCachingTime(url, headers) {
 		// false means "no caching"
 		var ttl = false,
-			headerName;
+			headerName,
+	   		now = new Date(),
+			headerDate;
 
 		for (headerName in headers) {
 			var value = headers[headerName];
@@ -39,6 +41,8 @@ exports.module = function(phantomas) {
 				case 'x-pass-cache-control':
 					phantomas.incrMetric('oldCachingHeaders'); // @desc number of responses with old, HTTP 1.0 caching headers (Expires and Pragma)
 					phantomas.addOffender('oldCachingHeaders', url + ' - ' + headerName + ': ' + value);
+					headerDate = Date.parse(value);
+					if (headerDate) ttl = (headerDate - now) / 1000;   
 					break;
 			}
 		}


### PR DESCRIPTION
Fix for #468: cachingNotSpecified reports files with the Expires: header specified (properly formatted)