### PR TITLE
Fix getDomPath with tab or new line seperated classe names

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -282,7 +282,7 @@
 			}
 			// div#foo.bar.test
 			else if (typeof node.className === 'string' && node.className !== '') {
-				entry += '.' + node.className.trim().replace(/ +/g, '.');
+				entry += '.' + node.className.trim().replace(/\s+/g, '.');
 			}
 			// div[0] <- index of child node
 			else if (node.parentNode instanceof Node) {


### PR DESCRIPTION
Hi @macbre!

Just a quick fix. The getDOMPath() function transforms`<div class="foo bar">` into `div.foo.bar`.

But there are some pages where class names are separated by tabs or `\n` and it is valid for browsers.
The problem is getDOMPath() transforms this into `div.foo	bar` (tab) or `div.foo\nbar`.

I suggest replacing the regexp `/ +/g` by `/\s+/g`.