### PR TITLE
Negative cache

### DIFF
--- a/modules/caching/caching.js
+++ b/modules/caching/caching.js
@@ -42,7 +42,7 @@ exports.module = function(phantomas) {
 					phantomas.incrMetric('oldCachingHeaders'); // @desc number of responses with old, HTTP 1.0 caching headers (Expires and Pragma)
 					phantomas.addOffender('oldCachingHeaders', url + ' - ' + headerName + ': ' + value);
 					headerDate = Date.parse(value);
-					if (headerDate) ttl = (headerDate - now) / 1000;
+					if (headerDate) ttl = Math.round((headerDate - now) / 1000);
 					break;
 			}
 		}

--- a/modules/caching/caching.js
+++ b/modules/caching/caching.js
@@ -66,7 +66,7 @@ exports.module = function(phantomas) {
 			if (ttl === false) {
 				phantomas.incrMetric('cachingNotSpecified');
 				phantomas.addOffender('cachingNotSpecified', entry.url);
-			} else if (ttl === 0) {
+			} else if (ttl <= 0) {
 				phantomas.incrMetric('cachingDisabled');
 				phantomas.addOffender('cachingDisabled', entry.url);
 			} else if (ttl < 7 * 86400) {


### PR DESCRIPTION
When a request is specifying an "Expires" header in the past, Phantomas counts it as a `cachingTooShort`. It is probably more correct to count it as a `cachingDisabled`. 

Example on this page http://www.francetvsport.fr there are several cachingTooShort offenders with a negative TTL.
Here is one of them:
```http://ib.adnxs.com/seg?add=577437&t=2 cached for -195163614.894 s```

The server responds with these headers:
```
Cache-Control:no-store, no-cache, private
Date:Thu, 22 Jan 2015 12:30:15 GMT
Expires:Sat, 15 Nov 2008 16:00:00 GMT
Pragma:no-cache
```

I also removed the milliseconds in the TTL.