### PR TITLE
Fix index of child node in getDOMPath

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -286,7 +286,7 @@
 			}
 			// div[0] <- index of child node
 			else if (node.parentNode instanceof Node) {
-				entry += '[' + Array.prototype.indexOf.call(node.parentNode.childNodes, node) + ']';
+				entry += '[' + Array.prototype.indexOf.call(node.parentNode.children, node) + ']';
 			}
 
 			path.push(entry);


### PR DESCRIPTION
Currently, getDOMPath counts both elements and text nodes when counting the index of an element. But even line breaks and spaces are counted as text nodes.

Example:
```html
<div>
  <ul>
    <li>whatever</li>
    <li>whatever</li>
    <li>whatever</li>
  </ul>
  <ul><li>whatever</li></ul>
</div>
```

Currently we would see in the offenders (domMaxDepth for example):
```
div > ul[1] > li[1]
div > ul[1] > li[3]
div > ul[1] > li[5]
div > ul[3] > li[0]
```

Changing `parentNode.childNodes` by `parentNode.children` fixes the problem:
```
div > ul[0] > li[0]
div > ul[0] > li[1]
div > ul[0] > li[2]
div > ul[1] > li[0]
```

What do you think?

-----------

( 
A unit test is failing on my computer, but it doesn't seem to be my fault: 
```
/timing.html
should have "requestsToDomContentLoaded" metric properly set 
        » expected 4, 
  	got	 3 (===)
```
)