### PR TITLE
Images scaled down: ignore SVG

### DIFF
--- a/test/webroot/image-scaling.html
+++ b/test/webroot/image-scaling.html
@@ -14,4 +14,5 @@
 	<img src="/static/blank.gif" alt="foo" height=10 width=10 /><!-- scaled up / ignore -->
 	<img src="/static/mdn.png" style="height: 50px; width: 50px" /><!-- CSS inlined + scaled down -->
 	<img src="/static/blank.gif" class="img" /><!-- missing inline dimensions, but get them via CSS class (will still be reported as having no dimensions defined) -->
+	<img src="/static/example.svg" height="50" width="50" /><!-- SVG  (ignore - ticket #479)-->
 </body>

--- a/test/webroot/static/example.svg
+++ b/test/webroot/static/example.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg"
+ width="467" height="462">
+  <rect x="80" y="60" width="250" height="250" rx="20"
+      style="fill:#ff0000; stroke:#000000;stroke-width:2px;" />
+
+  <rect x="140" y="120" width="250" height="250" rx="40"
+      style="fill:#0000ff; stroke:#000000; stroke-width:2px;
+      fill-opacity:0.7;" />
+</svg>


### PR DESCRIPTION
See #479

```
21:53:01.123 recv: HTTP 200 <http://0.0.0.0:8888/static/example.svg> [image/svg+xml]
21:53:01.124 Event recv emitted
21:53:01.124 imagesScaledDown: will ignore <http://0.0.0.0:8888/static/example.svg> [image/svg+xml]
...
21:53:02.166 imagesScaledDown: ignored <http://0.0.0.0:8888/static/example.svg> (is SVG)
```