### PR TITLE
Upgrading ascii-table to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "analyze-css": "0.9.2",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.0",
-    "ascii-table": "0.0.7",
+    "ascii-table": "0.0.8",
     "async": "~0.9.0",
     "csv-string": "~2.2.2",
     "debug": "~2.1.0",


### PR DESCRIPTION
Addresses an issue with `0` values not displaying in the table.