### PR TITLE
Scope problem with the spied version of eval()

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ phantomas https://github.com/macbre/phantomas --verbose --no-externals --allow-d
 * `--proxy-type=[http|socks5|none]` specifies the type of the proxy server (default is http)
 * `--phone` force viewport and user agent of a mobile phone
 * `--tablet` force viewport and user agent of a tablet
+* `--spy-eval` report calls to eval()
 
 ### Multiple runs
 

--- a/bin/phantomas.js
+++ b/bin/phantomas.js
@@ -55,6 +55,7 @@ program
 	.describe('har', 'save HAR to a given file')
 	.describe('silent', 'don\'t write anything to the console').boolean('silent')
 	.describe('skip-modules', 'skip selected modules [moduleOne],[moduleTwo],...')
+	.describe('spy-eval', 'report calls to eval()').boolean('spy-eval')
 	.describe('tablet', 'force viewport and user agent of a tablet')
 	.describe('timeout', 'timeout for phantomas run').default('timeout', 15)
 	.describe('user-agent', 'provide a custom user agent')

--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -782,11 +782,13 @@
     },
     "documentWriteCalls": {
       "desc": "number of calls to either document.write or document.writeln",
+      "offenders": true,
       "unit": "number",
       "module": "javaScriptBottlenecks"
     },
     "evalCalls": {
       "desc": "number of calls to eval (either direct or via setTimeout / setInterval)",
+      "offenders": true,
       "unit": "number",
       "module": "javaScriptBottlenecks"
     },
@@ -993,5 +995,5 @@
   },
   "metricsCount": 166,
   "modulesCount": 34,
-  "version": "1.8.0"
+  "version": "1.9.0"
 }

--- a/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
+++ b/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
@@ -4,30 +4,42 @@
  * @see http://www.nczonline.net/blog/2013/06/25/eval-isnt-evil-just-misunderstood/
  * @see http://www.quirksmode.org/blog/archives/2005/06/three_javascrip_1.html
  * @see http://www.stevesouders.com/blog/2012/04/10/dont-docwrite-scripts/
+ *
+ * Run phantomas with --spy-eval to count eval() calls (see issue #467)
  */
 /* global document: true, window: true */
 'use strict';
 
-exports.version = '0.1';
+exports.version = '0.2';
 
 exports.module = function(phantomas) {
 	phantomas.setMetric('documentWriteCalls'); //@desc number of calls to either document.write or document.writeln
 	phantomas.setMetric('evalCalls'); // @desc number of calls to eval (either direct or via setTimeout / setInterval)
 
+	// spy calls to eval only when requested (issue #467)
+	var spyEval = phantomas.getParam('spy-eval') === true;
+	if (!spyEval) {
+		phantomas.log('javaScriptBottlenecks: to spy calls to eval() run phantomas with --spy-eval option');
+	}
+
 	phantomas.once('init', function() {
-		phantomas.evaluate(function() {
+		phantomas.evaluate(function(spyEval) {
 			(function(phantomas) {
 				function report(msg, caller, backtrace, metric) {
 					phantomas.log(msg + ': from ' + caller + '!');
 					phantomas.log('Backtrace: ' + backtrace);
+
 					phantomas.incrMetric(metric);
+					phantomas.addOffender(metric, "%s from %s", msg, caller);
 				}
 
 				// spy calls to eval()
-				phantomas.spy(window, 'eval', function(code) {
-					report('eval() called directly', phantomas.getCaller(), phantomas.getBacktrace(), 'evalCalls');
-					phantomas.log('eval\'ed code: ' + (code || '').substring(0, 150) + '(...)');
-				});
+				if (spyEval) {
+					phantomas.spy(window, 'eval', function(code) {
+						report('eval() called directly', phantomas.getCaller(), phantomas.getBacktrace(), 'evalCalls');
+						phantomas.log('eval\'ed code: ' + (code || '').substring(0, 150) + '(...)');
+					});
+				}
 
 				// spy calls to setTimeout / setInterval with string passed instead of a function
 				phantomas.spy(window, 'setTimeout', function(fn, interval) {
@@ -51,6 +63,6 @@ exports.module = function(phantomas) {
 					report('document.writeln() used', phantomas.getCaller(), phantomas.getBacktrace(), 'documentWriteCalls');
 				});
 			})(window.__phantomas);
-		});
+		}, spyEval);
 	});
 };

--- a/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
+++ b/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
@@ -13,8 +13,8 @@
 exports.version = '0.2';
 
 exports.module = function(phantomas) {
-	phantomas.setMetric('documentWriteCalls'); //@desc number of calls to either document.write or document.writeln
-	phantomas.setMetric('evalCalls'); // @desc number of calls to eval (either direct or via setTimeout / setInterval)
+	phantomas.setMetric('documentWriteCalls'); //@desc number of calls to either document.write or document.writeln @offenders
+	phantomas.setMetric('evalCalls'); // @desc number of calls to eval (either direct or via setTimeout / setInterval) @offenders
 
 	// spy calls to eval only when requested (issue #467)
 	var spyEval = phantomas.getParam('spy-eval') === true;

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -163,4 +163,16 @@
     requests: 4
     requestsToDomContentLoaded: 4
     requestsToDomComplete: 4
+# JS bottlenecks (#467)
+- url: "/bottlenecks.html"
+  label: "/bottlenecks.html (--spy-eval)"
+  options:
+    "spy-eval": true
+  metrics:
+    documentWriteCalls: 1
+    evalCalls: 2 # via eval() and setTimeout()
+- url: "/bottlenecks.html"
+  metrics:
+    documentWriteCalls: 1
+    evalCalls: 1 # via setTimeout() only
 

--- a/test/webroot/bottlenecks.html
+++ b/test/webroot/bottlenecks.html
@@ -1,0 +1,12 @@
+<script>
+	var a = 1;
+
+	function foo() {
+		console.log('test');
+	}
+
+	eval('a += 2');
+	setTimeout('foo()', 0);
+
+	document.write('hello: a = ' + a);
+</script>


### PR DESCRIPTION
Introduce `--spy-eval` option to allow spying of `eval` calls only when requested to avoid scoping problems.

Additionally, offenders are now emitted:

```
Offenders for documentWriteCalls (1):
 * document.write() used from http://0.0.0.0:8888/bottlenecks.html:11

Offenders for evalCalls (2):
 * eval() called directly from http://0.0.0.0:8888/bottlenecks.html:8
 * eval() called via setTimeout("foo()") from http://0.0.0.0:8888/bottlenecks.html:9
```

Resolves #467