### PR TITLE
Fix a rare bug with DOMidDuplicated

### DIFF
--- a/modules/domComplexity/domComplexity.js
+++ b/modules/domComplexity/domComplexity.js
@@ -90,7 +90,7 @@ exports.module = function(phantomas) {
 							}
 
 							// report duplicated ID (issue #392)
-							if (node.id) {
+							if (typeof node.id === 'string' && node.id !== '') {
 								phantomas.emit('domId', node.id);
 							}
 


### PR DESCRIPTION
If the page contains a form with or without an id, and if this form contains a field named "id", like this:
```html
<form>
    <input name="id" value=""></input>
</form>
```

Then Phantomas creates this jsError:
```
Error: phantomas: calling native console.log() failed (\"TypeError: JSON.stringify cannot serialize cyclic structures.\")! - sendMsg phantomas/core/scope.js:127 / emit phantomas/core/scope.js:161
```

On a real browser, `document.querySelector('form').id` returns the id of the form, but on PhantomJS it returns the input field.

Here is the page where I had the bug: http://blog.teamtreehouse.com/