### PR TITLE
Improve timeouts handling

### DIFF
--- a/core/reporter.js
+++ b/core/reporter.js
@@ -30,15 +30,9 @@ module.exports = function(results, options) {
 
 	debug('Setting up %s reporter (options: %j)...', reporterName, reporterOptions);
 
-	// make the results "flat" - i.e. single run mode
 	if (Array.isArray(results)) {
-		if (results.length === 1) {
-			debug('Single run mode');
-			results = results[0];
-		} else {
-			debug('Multiple runs mode');
-			inMultipleMode = true;
-		}
+		debug('Multiple runs mode');
+		inMultipleMode = true;
 	}
 
 	// load the reporter


### PR DESCRIPTION
Skip the failed tests (when in multiple runs mode) and only include the
successful ones in the stats.

```
  phantomas:runs results [2]: [{},{}] +0ms
  phantomas:runs Run #1 did not complete - err #252 +2ms
  phantomas:runs 1 of 2 run(s) completed with exit code #0 +0ms
  phantomas:runs Calling a reporter... +9ms
```

Resolves #380