### PR TITLE
Set window.screen.width and window.screen.height

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -386,10 +386,19 @@ phantomas.prototype = {
 		var parsedViewport = this.getParam('viewport', '1366x768', 'string').split('x');
 
 		if (parsedViewport.length === 2) {
-			this.page.viewportSize = {
-				width: parseInt(parsedViewport[0], 10) || 1280,
-				height: parseInt(parsedViewport[1], 10) || 1024
+			var viewportSize = {
+				width: parseInt(parsedViewport[0], 10) || 1366,
+				height: parseInt(parsedViewport[1], 10) || 768
 			};
+			
+			this.page.viewportSize = viewportSize;
+
+			var self = this;
+			this.on('init', function() {
+				self.page.evaluate(function(viewportSize) {
+					window.screen = viewportSize;
+				}, viewportSize);
+			});
 		}
 
 		// setup user agent /  --user-agent=custom-agent

--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -396,16 +396,20 @@ phantomas.prototype = {
 			var self = this;
 			this.on('init', function() {
 				self.page.evaluate(function(viewportSize) {
-					window.screen = {
-						width: viewportSize.width,
-						height: viewportSize.height,
-						availWidth: viewportSize.width,
-						availHeight: viewportSize.height,
-						availLeft: 0,
-						availTop: 0,
-						colorDepth: 24,
-						pixelDepth: 24
-					};
+					try {
+						window.screen = {
+							width: viewportSize.width,
+							height: viewportSize.height,
+							availWidth: viewportSize.width,
+							availHeight: viewportSize.height,
+							availLeft: 0,
+							availTop: 0,
+							colorDepth: 24,
+							pixelDepth: 24
+						};
+					} catch (ex) {
+						// SlimmerJS complains: "Error: setting a property that has only a getter"
+					}
 				}, viewportSize);
 			});
 		}

--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -381,6 +381,8 @@ phantomas.prototype = {
 		}
 
 		this.start = Date.now();
+		
+		var self = this;
 
 		// setup viewport / --viewport=1366x768
 		var parsedViewport = this.getParam('viewport', '1366x768', 'string').split('x');
@@ -393,7 +395,6 @@ phantomas.prototype = {
 			
 			this.page.viewportSize = viewportSize;
 
-			var self = this;
 			this.on('init', function() {
 				self.page.evaluate(function(viewportSize) {
 					try {
@@ -447,8 +448,6 @@ phantomas.prototype = {
 
 		// observe HTTP requests
 		// finish when the last request is completed + one second timeout
-		var self = this;
-
 		this.reportQueue.push(function(done) {
 			var currentRequests = 0,
 				requestsUrls = {},

--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -396,7 +396,16 @@ phantomas.prototype = {
 			var self = this;
 			this.on('init', function() {
 				self.page.evaluate(function(viewportSize) {
-					window.screen = viewportSize;
+					window.screen = {
+						width: viewportSize.width,
+						height: viewportSize.height,
+						availWidth: viewportSize.width,
+						availHeight: viewportSize.height,
+						availLeft: 0,
+						availTop: 0,
+						colorDepth: 24,
+						pixelDepth: 24
+					};
 				}, viewportSize);
 			});
 		}


### PR DESCRIPTION
This pull request fixes window.screen.width and height not being set correctly when running in `--phone` or `--tablet` mode. Some websites use these properties to detect a mobile as a substitute to user-agent sniffing.

@macbre Here is the pull request! Since yesterday I added some forgotten properties to the window.screen object.