### PR TITLE
Fix --wait-for-selector

### DIFF
--- a/extensions/waitForSelector/waitForSelector.js
+++ b/extensions/waitForSelector/waitForSelector.js
@@ -8,7 +8,7 @@ exports.version = '0.2';
 
 function checkSelector(phantomas, selector) {
 	var res = phantomas.evaluate(function(selector) {
-		(function(phantomas) {
+		return (function(phantomas) {
 			try {
 				var result;
 

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -151,6 +151,13 @@
   metrics:
     DOMqueries: 0 # no queries should be reported despite DOM being polled by waitForSelector module
   exitCode: 252 # timeout
+# --wait-for-selector (issue #512)
+- url: "/wait-for-selector.html"
+  options:
+    timeout: 10
+    'wait-for-selector': ".bar:nth-child(4):last-child"
+  metrics:
+    DOMelementsCount: 4
 # --wait-for-event (issue #453)
 - url: "/wait-for-event.html"
   options:

--- a/test/webroot/wait-for-selector.html
+++ b/test/webroot/wait-for-selector.html
@@ -1,0 +1,16 @@
+<body>
+	<script>
+		window.onload = function() {
+			
+			// The --wait-for-selector option is set to: ".bar:nth-child(4):last-child".
+			// The following script creates a new div every 0.5 second. When the third div is
+			// created, Phantomas should stop waiting (the script element counts as one child)
+
+			setInterval(function() {
+				var div = document.createElement('div');
+				div.className = 'bar';
+				document.body.appendChild(div);
+			}, 500);
+		};
+	</script>
+</body>


### PR DESCRIPTION
Hi!

The --wait-for-selector option is currently broken.
The `document.querySelector()` call is trapped inside a scope-isolating function and can't return its result to the `phantomas.evaluate` function.