### PR TITLE
eventsScrollBound on document too

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Units:
 
 * eventsBound: number of ``EventTarget.addEventListener`` calls
 * eventsDispatched: number of ``EventTarget.dispatchEvent`` calls
-* eventsScrollBound: number of `scroll` event bounds to `window`
+* eventsScrollBound: number of `scroll` event bounds to `window` or `document`
 
 ### Window performance
 

--- a/modules/events/events.js
+++ b/modules/events/events.js
@@ -25,7 +25,7 @@ exports.module = function(phantomas) {
 					phantomas.addOffender('eventsBound', '"%s" bound to "%s"', eventType, path);
 
 					// count window.addEventListener('scroll', ...) - issue #508
-					if (eventType === 'scroll' && path === 'window') {
+					if (eventType === 'scroll' && (path === 'window' || path === '#document')) {
 						phantomas.incrMetric('eventsScrollBound');
 						phantomas.addOffender('eventsScrollBound', 'bound by %s', phantomas.getBacktrace());
 					}

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -120,9 +120,9 @@
     jQueryWindowOnLoadFunctions: 1
     jQuerySizzleCalls: 1
     jQueryEventTriggers: 2
-    eventsBound: 6
+    eventsBound: 7
     eventsDispatched: 1
-    eventsScrollBound: 1
+    eventsScrollBound: 2
 # multiple jQuery "instances" (issue #435)
 - url: "/jquery-multiple.html"
   metrics:

--- a/test/webroot/jquery.html
+++ b/test/webroot/jquery.html
@@ -40,8 +40,8 @@
 			ev.initCustomEvent('click');
 			$node[0].dispatchEvent(ev);
 
-			// scroll event
-			$(window).scroll(function(ev) {
+			// scroll events
+			$(window).add(document).scroll(function(ev) {
 				console.log(ev);
 			});
 		});


### PR DESCRIPTION
I'm realizing that the scroll event can be bound to `document`. It seems to do exactly the same as on `window`, but some developers or libraries do it that way.

Sorry I didn't figure it out sooner, when filling the primary issue!