### PR TITLE
Don't count duplicated queries on elements not attached to DOM

### DIFF
--- a/modules/domQueries/domQueries.js
+++ b/modules/domQueries/domQueries.js
@@ -126,7 +126,15 @@ exports.module = function(phantomas) {
 		phantomas.log('DOM query: by %s - "%s" (using %s) in %s', type, query, fnName, context);
 		phantomas.incrMetric('DOMqueries');
 
-		DOMqueries.push(type + ' "' + query + '" (in ' + context + ')');
+		// Don't count document fragments or not yet inserted elements inside duplicated queries
+		if (context && (
+                context.indexOf('html') === 0 ||
+                context.indexOf('body') === 0 ||
+                context.indexOf('head') === 0 ||
+                context.indexOf('#document') === 0
+            )) {
+			DOMqueries.push(type + ' "' + query + '" (in ' + context + ')');
+		}
 	});
 
 	phantomas.on('report', function() {

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -43,15 +43,15 @@
     cssCount: 1
     jsCount: 1
     domains: 1
-    DOMqueries: 18
+    DOMqueries: 20
     DOMqueriesById: 7
     DOMqueriesByClassName: 1
-    DOMqueriesByTagName: 7
+    DOMqueriesByTagName: 9
     DOMqueriesByQuerySelectorAll: 3
     DOMinserts: 2 # "div" appended to "html" (from jQuery) and the one below
     DOMmutationsInserts: 1 # DocumentFragment > b[0]" appended to "body > p#foo"
-    DOMqueriesDuplicated: 3
-    DOMqueriesAvoidable: 4
+    DOMqueriesDuplicated: 2
+    DOMqueriesAvoidable: 3
     DOMqueriesWithoutResults: 4
 # DOM complexity
 - url: "/dom-complexity.html"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -23,15 +23,15 @@
     cssCount: 1
     jsCount: 1
     domains: 1
-    DOMqueries: 18
+    DOMqueries: 20
     DOMqueriesById: 7
     DOMqueriesByClassName: 1
-    DOMqueriesByTagName: 7
+    DOMqueriesByTagName: 9
     DOMqueriesByQuerySelectorAll: 3
     DOMinserts: 2
     DOMmutationsInserts: 0
-    DOMqueriesDuplicated: 3
-    DOMqueriesAvoidable: 4
+    DOMqueriesDuplicated: 2
+    DOMqueriesAvoidable: 3
     DOMqueriesWithoutResults: 4
 # DOM operations (in SlimerJS)
 - url: "/dom-operations.html"

--- a/test/webroot/dom-operations.html
+++ b/test/webroot/dom-operations.html
@@ -31,6 +31,9 @@
 			var nodeToRemove = document.getElementById('delete');
 			document.body.removeChild(nodeToRemove);
 
+			var detachedDiv1 = document.createElement('div');
+			var detachedDiv2 = document.createElement('div');
+
 			var nodes = [
 				document.querySelector('#foo'),
 				document.querySelector('ol li'), // DOMqueriesWithoutResults++
@@ -42,6 +45,8 @@
 				document.getElementById('list1').getElementsByTagName('li'),
 				document.getElementById('list2').getElementsByTagName('li'),
 				document.getElementById('foobar'), // DOMqueriesWithoutResults++
+				detachedDiv1.getElementsByTagName('a'),
+				detachedDiv2.getElementsByTagName('a'),// should not be counted as duplicated query
 			];
 
 			console.log(nodes);


### PR DESCRIPTION
Hi there!

Some DOM queries are counted as duplicated but aren't. Example: 
```js
var detachedDiv1 = document.createElement('div');
var detachedDiv2 = document.createElement('div');

detachedDiv1.getElementsByTagName('a');
detachedDiv2.getElementsByTagName('a');// should not be counted as duplicated query
```

Currently, they are counted as duplicated and this is the offender: 
``` * tag name "a" (in div): 2 queries```


Same thing with elements inside document fragments. While it's sometimes true, we can't be sure the browser is running the query inside the same document fragment.
