### PR TITLE
requetsTo* related metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Only ``plain`` (the default one) and ``json`` reporters are currently supported 
 
 ## Metrics
 
-_Current number of metrics: 130_
+_Current number of metrics: 134_
 
 Units:
 
@@ -307,8 +307,12 @@ Units:
 
 ### Requests to
 
+* requestsToFirstPaint: number of HTTP requests it took to make the first paint
+* domainsToFirstPaint: number of domains used to make the first paint
 * requestsToDomContentLoaded: number of HTTP requests it took to make the page reach `DomContentLoaded` state
+* domainsToDomContentLoaded: number of domains used to make the page reach DomContentLoaded state
 * requestsToDomComplete: number of HTTP requests it took to make the page reach `DomComplete` state
+* domainsToDomComplete: number of domains used to make the page reach DomComplete state
 
 ### keepAlive
 

--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -899,13 +899,38 @@
       "unit": "ms",
       "module": "requestsStats"
     },
+    "requestsToFirstPaint": {
+      "desc": "number of HTTP requests it took to make the first paint",
+      "gecko": true,
+      "unit": "number",
+      "module": "requestsTo"
+    },
+    "domainsToFirstPaint": {
+      "desc": "number of domains used to make the first paint   @offenders",
+      "offenders": true,
+      "gecko": true,
+      "unit": "number",
+      "module": "requestsTo"
+    },
     "requestsToDomContentLoaded": {
       "desc": "number of HTTP requests it took to make the page reach DomContentLoaded state",
       "unit": "number",
       "module": "requestsTo"
     },
+    "domainsToDomContentLoaded": {
+      "desc": "number of domains used to make the page reach DomContentLoaded state",
+      "offenders": true,
+      "unit": "number",
+      "module": "requestsTo"
+    },
     "requestsToDomComplete": {
       "desc": "number of HTTP requests it took to make the page reach DomComplete state",
+      "unit": "number",
+      "module": "requestsTo"
+    },
+    "domainsToDomComplete": {
+      "desc": "number of domains used to make the page reach DomComplete state",
+      "offenders": true,
       "unit": "number",
       "module": "requestsTo"
     },
@@ -1005,7 +1030,7 @@
       "module": "windowPerformance"
     }
   },
-  "metricsCount": 168,
+  "metricsCount": 172,
   "modulesCount": 35,
   "version": "1.10.2"
 }

--- a/modules/repaints/repaints.js
+++ b/modules/repaints/repaints.js
@@ -31,6 +31,7 @@ exports.module = function(phantomas) {
 					if (window.mozPaintCount > lastPaintCountValue) {
 						if (lastPaintCountValue === 0) {
 							phantomas.emit('firstPaint'); // @desc fired on the first paint @desc
+							phantomas.emit('milestone', 'firstPaint');
 						}
 
 						lastPaintCountValue = window.mozPaintCount;

--- a/modules/requestsTo/requestsTo.js
+++ b/modules/requestsTo/requestsTo.js
@@ -3,29 +3,54 @@
  */
 'use strict';
 
-exports.version = '0.1';
+exports.version = '1.0';
 
 exports.module = function(phantomas) {
+	phantomas.setMetric('requestsToFirstPaint'); // @desc number of HTTP requests it took to make the first paint @gecko
+	phantomas.setMetric('domainsToFirstPaint'); // @desc number of domains used to make the first paint @offenders @gecko @offenders
 	phantomas.setMetric('requestsToDomContentLoaded'); // @desc number of HTTP requests it took to make the page reach DomContentLoaded state
+	phantomas.setMetric('domainsToDomContentLoaded'); // @desc number of domains used to make the page reach DomContentLoaded state @offenders
 	phantomas.setMetric('requestsToDomComplete'); // @desc number of HTTP requests it took to make the page reach DomComplete state
+	phantomas.setMetric('domainsToDomComplete'); // @desc number of domains used to make the page reach DomComplete state @offenders
 
-	var requests = 0;
+	var Collection = require('../../lib/collection'),
+		domains = new Collection(),
+		requests = 0;
+
+	function setDomainMetric(metricName) {
+		phantomas.setMetric(metricName, domains.getLength());
+		domains.sort().forEach(function(domain, cnt) {
+			phantomas.addOffender(metricName, '%s (%d requests)', domain, cnt);
+		});
+	}
 
 	phantomas.on('recv', function(entry, res) {
+		//phantomas.log('requestsTo: #%d <%s> / %s', requests, entry.url, entry.domain);
+
 		requests++;
-		//phantomas.log('requestsTo: #%d <%s>', requests, entry.url);
+
+		if (entry.domain) {
+			domains.push(entry.domain);
+		}
 	});
 
 	phantomas.on('milestone', function(name) {
 		//phantomas.log('requestsTo: %s (after %d requests)', name, requests);
 
 		switch (name) {
+			case 'firstPaint':
+				phantomas.setMetric('requestsToFirstPaint', requests);
+				setDomainMetric('domainsToFirstPaint');
+				break;
+
 			case 'domInteractive':
 				phantomas.setMetric('requestsToDomContentLoaded', requests);
+				setDomainMetric('domainsToDomContentLoaded');
 				break;
 
 			case 'domComplete':
 				phantomas.setMetric('requestsToDomComplete', requests);
+				setDomainMetric('domainsToDomComplete');
 				break;
 		}
 	});

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -165,12 +165,14 @@
     'wait-for-event': "done"
   metrics:
     testFooBar: 123 # a metric set just before event trigger
-# requests to (issue #438)
+# requests to (#438 / #486)
 - url: "/timing.html"
   metrics:
     requests: 4
     requestsToDomContentLoaded: 4
+    domainsToDomContentLoaded: 1
     requestsToDomComplete: 4
+    domainsToDomComplete: 1
 # JS bottlenecks (#467)
 - url: "/bottlenecks.html"
   label: "/bottlenecks.html (--spy-eval)"


### PR DESCRIPTION
```
Offenders for domainsToDomContentLoaded (10):
 * fil.nrk.no (23 requests)
 * www.yr.no (14 requests)
 * symbol.yr.no (6 requests)
 * gfx.nrk.no (4 requests)
 * www.google-analytics.com (2 requests)
 * cdn.cxense.com (1 requests)
 * ll.lp4.io (1 requests)
 * ajax.aspnetcdn.com (1 requests)
 * comcluster.cxense.com (1 requests)
 * p.lp4.io (1 requests)
```

Resolves #486