### PR TITLE
Do not fail when importing not existing engine

### DIFF
--- a/lib/engines.js
+++ b/lib/engines.js
@@ -24,10 +24,16 @@ function engines(options) {
 }
 
 engines.prototype.registerEngine = function(engineName) {
-	var def = require('./engines/' + engineName);
-	this.engines[engineName] = def;
+	var def;
 
-	debug('Engine "%s": %s v%s installed in %s', engineName, def.name, def.version, def.path);
+	try {
+		def = require('./engines/' + engineName);
+		this.engines[engineName] = def;
+
+		debug('Engine "%s": %s v%s installed in %s', engineName, def.name, def.version, def.path);
+	} catch (ex) {
+		debug('Engine "%s": failed to import - %s', engineName, ex);
+	}
 };
 
 engines.prototype.getEngines = function() {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -44,8 +44,7 @@ spec.forEach(function(test) {
 			topic: 'foo',
 			'should be skipped': function() {}
 		};
-	}
-	else {
+	} else {
 		batch[batchName] = {
 			topic: function() {
 				phantomas(WEBROOT + test.url, test.options || {}, this.callback);


### PR DESCRIPTION
See #488

```
  phantomas:engines Engine "webkit2": failed to import - Error: Cannot find module 'phantomjs2'
```

`phantomjs2` npm module fails to install on Linux ia32:

```
> phantomjs2@2.0.0-alpha install /home/macbre/github/phantomas/node_modules/phantomjs2
> node install.js

There is no prebuilt binary for your platform: linux ia32 3.2.0-4-686-pae
You should install phantomjs from source, put the binary on your PATH, and try again

npm ERR! phantomjs2@2.0.0-alpha install: `node install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the phantomjs2@2.0.0-alpha install script.
npm ERR! This is most likely a problem with the phantomjs2 package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node install.js
npm ERR! You can get their info via:
npm ERR!     npm owner ls phantomjs2
npm ERR! There is likely additional logging output above.
```