### PR TITLE
Send basic auth to analyze-css

### DIFF
--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -75,6 +75,12 @@ exports.module = function(phantomas) {
 		// force JSON output format
 		options.push('--json');
 
+		// set basic auth if needed
+		if (phantomas.getParam('auth-user') && phantomas.getParam('auth-pass')) {
+			options.push('--auth-user', phantomas.getParam('auth-user'));
+			options.push('--auth-pass', phantomas.getParam('auth-pass'));
+		}
+
 		phantomas.runScript('node_modules/.bin/' + binary, options, function(err, results) {
 			var offenderSrc = (options[0] === '--url') ? '<' + options[1] + '>' : '[inline CSS]';
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "analyze-css": "0.9.x",
+    "analyze-css": "0.10.x",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.0",
     "ascii-table": "0.0.8",


### PR DESCRIPTION
Since analyze-css 1.10.0 [accepts basic auth arguments](https://github.com/macbre/analyze-css/pull/103), lets make Phantomas transmit them correctly.