### PR TITLE
Small fixes for hidden images

### DIFF
--- a/modules/domHiddenContent/domHiddenContent.js
+++ b/modules/domHiddenContent/domHiddenContent.js
@@ -46,7 +46,7 @@ exports.module = function(phantomas) {
 										var src = images[i].src,
 											path;
 
-										if (src.indexOf('data:image') === 0) return;
+										if (src.indexOf('data:image') === 0) continue;
 
 										if (!lazyLoadableImages[src]) {
 											path = phantomas.getDOMPath(images[i]);

--- a/modules/domHiddenContent/domHiddenContent.js
+++ b/modules/domHiddenContent/domHiddenContent.js
@@ -46,7 +46,7 @@ exports.module = function(phantomas) {
 										var src = images[i].src,
 											path;
 
-										if (src.indexOf('data:image') === 0) continue;
+										if (src === '' || src.indexOf('data:image') === 0) continue;
 
 										if (!lazyLoadableImages[src]) {
 											path = phantomas.getDOMPath(images[i]);

--- a/modules/domHiddenContent/domHiddenContent.js
+++ b/modules/domHiddenContent/domHiddenContent.js
@@ -39,22 +39,25 @@ exports.module = function(phantomas) {
 								}
 
 								// count hidden images that can be lazy loaded (issue #524)
-								if (typeof node.querySelectorAll === 'function') {
-									var images = node.querySelectorAll('img') || [];
+								var images = [];
+								if (node.tagName === 'IMG') {
+									images = [node];
+								} else if (typeof node.querySelectorAll === 'function') {
+									images = node.querySelectorAll('img') || [];
+								}
 
-									for (var i = 0, len = images.length; i < len; i++) {
-										var src = images[i].src,
-											path;
+								for (var i = 0, len = images.length; i < len; i++) {
+									var src = images[i].src,
+										path;
 
-										if (src === '' || src.indexOf('data:image') === 0) continue;
+									if (src === '' || src.indexOf('data:image') === 0) continue;
 
-										if (!lazyLoadableImages[src]) {
-											path = phantomas.getDOMPath(images[i]);
+									if (!lazyLoadableImages[src]) {
+										path = phantomas.getDOMPath(images[i]);
 
-											lazyLoadableImages[src] = {
-												path: path
-											};
-										}
+										lazyLoadableImages[src] = {
+											path: path
+										};
 									}
 								}
 

--- a/modules/lazyLoadableImages/lazyLoadableImages.js
+++ b/modules/lazyLoadableImages/lazyLoadableImages.js
@@ -35,7 +35,7 @@ exports.module = function(phantomas) {
 					src = images[i].src;
 
 					// ignore base64-encoded images
-					if (/^data:/.test(src)) {
+					if (src === '' || /^data:/.test(src)) {
 						continue;
 					}
 

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -33,17 +33,17 @@
 # DOM complexity
 - url: "/dom-complexity.html"
   metrics:
-    bodyHTMLSize: 524
-    commentsSize: 48
-    DOMelementsCount: 9
+    bodyHTMLSize: 626
+    commentsSize: 85
+    DOMelementsCount: 10
     DOMelementMaxDepth: 2
     DOMidDuplicated: 0
-    hiddenContentSize: 270
+    hiddenContentSize: 372
     imagesScaledDown: 0
     imagesWithoutDimensions: 3
     hiddenImages: 2
     nodesWithInlineCSS: 1
-    whiteSpacesSize: 28
+    whiteSpacesSize: 31
 # document height
 - url: "/document-height.html"
   metrics:

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -33,17 +33,17 @@
 # DOM complexity
 - url: "/dom-complexity.html"
   metrics:
-    bodyHTMLSize: 626
+    bodyHTMLSize: 709
     commentsSize: 85
-    DOMelementsCount: 10
+    DOMelementsCount: 11
     DOMelementMaxDepth: 2
     DOMidDuplicated: 0
-    hiddenContentSize: 372
+    hiddenContentSize: 373
     imagesScaledDown: 0
     imagesWithoutDimensions: 3
-    hiddenImages: 2
+    hiddenImages: 3
     nodesWithInlineCSS: 1
-    whiteSpacesSize: 31
+    whiteSpacesSize: 33
 # document height
 - url: "/document-height.html"
   metrics:

--- a/test/webroot/dom-complexity.html
+++ b/test/webroot/dom-complexity.html
@@ -13,6 +13,7 @@
 		<img src="/static/mdn.png" width=600 height=529 />
 		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" /><!-- ignore base6-encoded images -->
 		<img src="/static/blank.gif" alt="foo" width=1 height=1 />
+		<img lzld-src="/static/lazyloaded.jpg" width=60 height=40 /><!-- ignore images with no source -->
 	</span>
 	<img src="/static/blank.gif" alt="foo" />
 	<img src="/static/blank.gif" alt="foo" height=1 />

--- a/test/webroot/dom-complexity.html
+++ b/test/webroot/dom-complexity.html
@@ -11,8 +11,8 @@
 	<span class="hidden">
 		<b>123</b>
 		<img src="/static/mdn.png" width=600 height=529 />
+		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D" /><!-- ignore base6-encoded images -->
 		<img src="/static/blank.gif" alt="foo" width=1 height=1 />
-		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"><!-- ignore base6-encoded images -->
 	</span>
 	<img src="/static/blank.gif" alt="foo" />
 	<img src="/static/blank.gif" alt="foo" height=1 />

--- a/test/webroot/dom-complexity.html
+++ b/test/webroot/dom-complexity.html
@@ -18,4 +18,5 @@
 	<img src="/static/blank.gif" alt="foo" />
 	<img src="/static/blank.gif" alt="foo" height=1 />
 	<img src="/static/blank.gif" alt="foo" height=1 width=1 />
+	<img class="hidden" src="/static/example.svg" alt="foo" height=467 width=462 />
 </body>

--- a/test/webroot/lazy-loadable-images.html
+++ b/test/webroot/lazy-loadable-images.html
@@ -29,5 +29,6 @@
 		<img src="/static/mdn.png" width=25><!-- the same image was above the fold - ignore -->
 		<img src="data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D"><!-- ignore base6-encoded images -->
 		<img src="/static/example.svg" height="50" width="50">
+		<img lzld-src="/static/lazyloaded.jpg" width=60 height=40 /><!-- ignore images with no source -->
 	</footer>
 </body>


### PR DESCRIPTION
Hi @macbre,

Thanx for the new **hiddenImages** metric!

I've been trying it and here is a couple of small fixes:

I assumed you wanted to use `continue` instead of return. It was causing some hidden images to be ignore if they were after a base64 images.

I also ignored images with no `src` attribute from lazyloadable and hidden images. I was seeing empty offenders a websites because of that.