### PR TITLE
Fix lazy load. Get scr via getAttribute.

### DIFF
--- a/modules/lazyLoadableImages/lazyLoadableImages.js
+++ b/modules/lazyLoadableImages/lazyLoadableImages.js
@@ -32,10 +32,10 @@ exports.module = function(phantomas) {
 				for (i = 0; i < len; i++) {
 					// @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
 					offset = images[i].getBoundingClientRect().top;
-					src = images[i].src;
+					src = images[i].getAttribute('src');
 
 					// ignore base64-encoded images
-					if (src === '' || /^data:/.test(src)) {
+					if (src === null || src === '' || /^data:/.test(src)) {
 						continue;
 					}
 


### PR DESCRIPTION
It was a problem with getting the right value, it could have been the URI of page in scr after getting instead of empty string. We have to use attribute instead of propertie.