### PR TITLE
Revert "DNS and Connect timings"

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Only ``plain`` (the default one) and ``json`` reporters are currently supported 
 
 ## Metrics
 
-_Current number of metrics: 139_
+_Current number of metrics: 135_
 
 Units:
 
@@ -296,13 +296,6 @@ Units:
 * domComplete: time it took to load all page resources, the loading spinner has stopped spinning
 * timeBackend: time to the first byte compared to the total loading time (in %)
 * timeFrontend: time to window on load compared to the total loading time (in %)
-
-> Below metrics are taken from [window.performance.timing](http://www.w3.org/TR/navigation-timing/) and require `gecko` or `webkit2` engine to be used
-
-* performanceTimingConnect: time it took to connect to the server before making the first HTTP request
-* performanceTimingDNS: time it took to resolve the domain before making the first HTTP request
-* performanceTimingPageLoad: time it took to fully load the page
-* performanceTimingTTFB: time it took to receive the first byte of the first HTTP response
 
 ### Repaints
 

--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -1031,29 +1031,9 @@
       "desc": "time to window.load compared to the total loading time",
       "unit": "%",
       "module": "windowPerformance"
-    },
-    "performanceTimingConnect": {
-      "desc": "time it took to connect to the server before making the first HTTP request",
-      "unit": "ms",
-      "module": "windowPerformance"
-    },
-    "performanceTimingDNS": {
-      "desc": "time it took to resolve the domain before making the first HTTP request",
-      "unit": "ms",
-      "module": "windowPerformance"
-    },
-    "performanceTimingPageLoad": {
-      "desc": "time it took to fully load the page",
-      "unit": "ms",
-      "module": "windowPerformance"
-    },
-    "performanceTimingTTFB": {
-      "desc": "time it took to receive the first byte of the first HTTP response",
-      "unit": "ms",
-      "module": "windowPerformance"
     }
   },
-  "metricsCount": 177,
+  "metricsCount": 173,
   "modulesCount": 35,
-  "version": "1.12.0"
+  "version": "1.11.0"
 }

--- a/modules/windowPerformance/windowPerformance.js
+++ b/modules/windowPerformance/windowPerformance.js
@@ -3,16 +3,11 @@
  *
  * @see http://w3c-test.org/webperf/specs/NavigationTiming/#dom-performancetiming-domloading
  * @see https://developers.google.com/web/fundamentals/performance/critical-rendering-path/measure-crp
- *
- * Use Resource Timing API to measure time spent on DNS and TCP connection
- *
- * @see http://www.w3.org/TR/navigation-timing/
- * @see http://www.stevesouders.com/blog/2014/08/21/resource-timing-practical-tips/
  */
-/* global document: true, window: true, PerformanceTiming: true */
+/* global document: true, window: true */
 'use strict';
 
-exports.version = '1.1';
+exports.version = '1.0';
 
 exports.module = function(phantomas) {
 	// times below are calculated relative to performance.timing.responseEnd (#117)
@@ -24,13 +19,6 @@ exports.module = function(phantomas) {
 	// backend vs frontend time
 	phantomas.setMetric('timeBackend'); // @desc time to the first byte compared to the total loading time [%]
 	phantomas.setMetric('timeFrontend'); // @desc time to window.load compared to the total loading time [%]
-
-	// get values from Resource Timing API (issue #477)
-	// set initial values to -1 as we expect the worst to happen ;)
-	phantomas.setMetric('performanceTimingConnect', -1); // @desc time it took to connect to the server before making the first HTTP request
-	phantomas.setMetric('performanceTimingDNS', -1); // @desc time it took to resolve the domain before making the first HTTP request
-	phantomas.setMetric('performanceTimingPageLoad', -1); // @desc time it took to fully load the page
-	phantomas.setMetric('performanceTimingTTFB', -1); // @desc time it took to receive the first byte of the first HTTP response
 
 	// measure dom... metrics from the moment HTML response was fully received
 	var responseEndTime = Date.now();
@@ -126,8 +114,7 @@ exports.module = function(phantomas) {
 		var backendTime = parseInt(phantomas.getMetric('timeToFirstByte'), 10),
 			frontendTime = parseInt(phantomas.getMetric('domComplete'), 10),
 			totalTime = backendTime + frontendTime,
-			backendTimePercentage,
-			timing;
+			backendTimePercentage;
 
 		if (totalTime === 0) {
 			return;
@@ -139,21 +126,5 @@ exports.module = function(phantomas) {
 		phantomas.setMetric('timeFrontend', 100 - backendTimePercentage);
 
 		phantomas.log('Performance timing: backend vs frontend time - %d% / %d%', backendTimePercentage, 100 - backendTimePercentage);
-
-		// try to take performance metrics from PerformanceTiming (issue #477)
-		if (!window.performance || !(window.performance.timing instanceof PerformanceTiming)) {
-			phantomas.log('performanceTiming: PerformanceTiming API not available!');
-			return;
-		}
-
-		phantomas.log('performanceTiming: data %j', window.performance.timing);
-
-		// @see http://www.stevesouders.com/blog/2014/08/21/resource-timing-practical-tips/
-		timing = window.performance.timing;
-
-		phantomas.setMetric('performanceTimingConnect', timing.connectEnd - timing.connectStart);
-		phantomas.setMetric('performanceTimingDNS', timing.domainLookupEnd - timing.domainLookupStart);
-		phantomas.setMetric('performanceTimingPageLoad', timing.loadEventStart - timing.navigationStart);
-		phantomas.setMetric('performanceTimingTTFB', timing.responseStart - timing.navigationStart);
 	});
 };

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -53,7 +53,8 @@ spec.forEach(function(test) {
 				if (test.exitCode) {
 					assert.ok(err instanceof Error);
 					assert.strictEqual(err.message, test.exitCode.toString(), 'Exit code matches the expected value');
-				} else {
+				}
+				else {
 					assert.equal(err, null, 'Exit code matches the expected value');
 				}
 			},


### PR DESCRIPTION
Reverts macbre/phantomas#567 /  #477

These metrics provide zero in 99,9% of cases in both SlimerJS and PhantomJS 2.x. Let's revert this change for now and wait until these values are actually usable.