### PR TITLE
requestsWithTimeout: always register the metric

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -491,6 +491,9 @@ phantomas.prototype = {
 						self.results.addOffender('requestsWithTimeout', url);
 					});
 				});
+
+				// always register the metric (issue #581)
+				self.results.setMetric('requestsWithTimeout', 0);
 			});
 		}
 


### PR DESCRIPTION
Fixes #581