### PR TITLE
add extra err check for analyzeCss result

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -834,9 +834,15 @@ phantomas.prototype = {
 
 			ctx = execFile(script, args, null, function(err, stdout, stderr) {
 				var time = Date.now() - start;
+				var result = stderr !== "" ? stderr : stdout;
 
 				if (err || stderr) {
 					self.log('runScript: pid #%d failed - %s (took %d ms)!', pid, (err || stderr || 'unknown error').trim(), time);
+
+					callback(err, result);
+
+					done();
+					return;
 				} else if (!pid) {
 					self.log('runScript: failed running %s %s!', script, args.join(' '));
 
@@ -848,11 +854,13 @@ phantomas.prototype = {
 
 				// (try to) parse JSON-encoded output
 				try {
-					callback(null, JSON.parse(stdout));
+					result = JSON.parse(stdout);
 				} catch (ex) {
-					self.log('runScript: JSON parsing failed!');
-					callback(stderr, stdout);
+					self.log('runScript: JSON parsing failed! - %s', ex);
+					err = ex;
 				}
+
+				callback(err, result);
 
 				done();
 			});

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -84,7 +84,7 @@ exports.module = function(phantomas) {
 		phantomas.runScript('node_modules/.bin/' + binary, options, function(err, results) {
 			var offenderSrc = (options[0] === '--url') ? '<' + options[1] + '>' : '[inline CSS]';
 
-			if (err !== null) {
+			if (err !== null && err !== "" && results && results.parsingErrors === 0) {
 				phantomas.log('analyzeCss: sub-process failed!');
 
 				// report failed CSS parsing (issue #494(

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -84,15 +84,21 @@ exports.module = function(phantomas) {
 		phantomas.runScript('node_modules/.bin/' + binary, options, function(err, results) {
 			var offenderSrc = (options[0] === '--url') ? '<' + options[1] + '>' : '[inline CSS]';
 
-			if (err !== null && err !== "" && results && results.parsingErrors === 0) {
-				phantomas.log('analyzeCss: sub-process failed!');
+			if (err) {
+				phantomas.log('analyzeCss: sub-process failed! - %s', err);
 
 				// report failed CSS parsing (issue #494(
 				var offender = offenderSrc;
-				if (err.indexOf('CSS parsing failed') > 0) {
-					offender += ' (' + err.trim() + ')';
-				} else if (err.indexOf('Empty CSS was provided') > 0) {
-					offender += ' (Empty CSS was provided)';
+				if (err.message) { // Error object returned
+					if (err.message.indexOf('Unable to parse JSON string') > 0) {
+						offender += ' (analyzeCss output error)';
+					}
+				} else { // Error string returned (stderror)
+					if (err.indexOf('CSS parsing failed') > 0) {
+						offender += ' (' + err.trim() + ')';
+					} else if (err.indexOf('Empty CSS was provided') > 0) {
+						offender += ' (Empty CSS was provided)';
+					}
 				}
 
 				phantomas.incrMetric('cssParsingErrors');

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -84,7 +84,7 @@ exports.module = function(phantomas) {
 		phantomas.runScript('node_modules/.bin/' + binary, options, function(err, results) {
 			var offenderSrc = (options[0] === '--url') ? '<' + options[1] + '>' : '[inline CSS]';
 
-			if (err) {
+			if (err !== null) {
 				phantomas.log('analyzeCss: sub-process failed! - %s', err);
 
 				// report failed CSS parsing (issue #494(


### PR DESCRIPTION
closes #580 

In node4 executing analyzeCss returns err === "". Previous code was taking this as an error (since it's !== null), I added more checks to avoid this.