### PR TITLE
Update SlimerJS min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "phantomjs2": "macbre/phantomjs2-npm#version-2.0",
     "progress": "~1.1.4",
     "q": "^1.4.1",
-    "slimerjs": "^0.9.5",
+    "slimerjs": "^0.9.6",
     "tap": "^0.7.1",
     "tap-eater": ">=0.0.1",
     "travis-fold": ">=0.1.2"


### PR DESCRIPTION
Hi!

My project contains phantomas as a npm dependency. For an unknown reason, when running `npm install` on Travis, npm tries to install the `slimerjs` package in version `0.9.5`, although version `0.9.6` exists.

And it fails! It looks like they recently changed the binaries download urls, that could explain the failure.
Take a look at this Travis build for example: https://travis-ci.org/gmetais/YellowLabTools/builds/101186325

Locally, or on my server, I have no problem, npm directly downloads `0.9.6`. The only bug is with my Travis. Your own Travis tests download the right version.

This merge request simply updates the minimal version of SlimerJS and it fixes my Travis problem.