### PR TITLE
npm install should install without compile error under Node 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "analyze-css": "0.10.x",
+    "analyze-css": "^0.10",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.0",
     "ascii-table": "0.0.8",


### PR DESCRIPTION
The issue is caused due to old version of analyze-css being loaded while the fixed version has been already released.