### PR TITLE
Fix --allow-domain option

### DIFF
--- a/modules/blockDomains/blockDomains.js
+++ b/modules/blockDomains/blockDomains.js
@@ -33,8 +33,12 @@ exports.module = function(phantomas) {
 		}
 
 		// match whitelist (--allow-domain)
-		if (allowedDomainsRegExp && allowedDomainsRegExp.test(domain)) {
-			blocked = false;
+		if (allowedDomainsRegExp) {
+			if (allowedDomainsRegExp.test(domain)) {
+				blocked = false;
+			} else {
+				blocked = true;
+			}
 		}
 
 		return blocked;


### PR DESCRIPTION
When using --allow-domain, no resource is ever blocked because the function can't return true.