### PR TITLE
Use phantomjs-prebuilt to provide PhantomJS 2.1.x binary

### DIFF
--- a/lib/engines/webkit2.js
+++ b/lib/engines/webkit2.js
@@ -1,9 +1,9 @@
 /**
  * Defines PhantomJS 2.x engine
  *
- * @see https://github.com/macbre/phantomas/pull/531
+ * @see https://github.com/macbre/phantomas/issues/488
  */
-var pkg = require('phantomjs2');
+var pkg = require('phantomjs-prebuilt');
 
 module.exports = {
 	name: 'PhantomJS',

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-uuid": "~1.4.1",
     "optimist": "0.6.x",
     "phantomjs": "^1.9.15",
-    "phantomjs2": "macbre/phantomjs2-npm#version-2.0.1",
+    "phantomjs-prebuilt": "^2.1.3",
     "progress": "~1.1.4",
     "q": "^1.4.1",
     "slimerjs": "^0.9.6",


### PR DESCRIPTION
Use `PhantomJS/2.1.1` when running with `--webkit2` option.

Resolves #488