### PR TITLE
Added aws cloudwatch as reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ phantomas https://github.com/macbre/phantomas --verbose --no-externals --allow-d
 
 #### Parameters
 
-* `--reporter=[json|csv|tap|plain|statsd|elasticsearch]` results reporter aka format (``plain`` is the default one)
+* `--reporter=[json|csv|tap|plain|statsd|elasticsearch|cloudwatch]` results reporter aka format (``plain`` is the default one)
 * `--timeout=[seconds]` timeout for phantomas run (defaults to 15 seconds)
 * `--viewport=[width]x[height]` phantomJS viewport dimensions (1280x1024 is the default)
 * `--verbose` writes debug messages to the console
@@ -465,6 +465,13 @@ This will omit CSV headers row and add current timestamp as the first column, so
 ##### TAP
 * ``no-skip`` - don't print out metrics that were skipped
 
+##### StatsD
+* ``<host>:<port>:<prefix>`` - shorthand for ``--statsd-host``, ``--statsd-port`` and ``--statsd-prefix`` (you don't need to provide all three options)
+
+
+##### Aws CloudWatch
+* ``<accessKeyId>:<secretKey>:<region>:<apiVersion>:<namespace>`` - shorthand for ``--aws-access-key-id``, ``--aws-secret-key``, ``--aws-region``, ``--aws-cloudwatch-api-version`` and ``--aws-cloudwatch-namespace`` (only AccessKeyId and SecretKey are required)
+
 #### StatsD integration
 
 Metrics from phantomas run can be sent directly to [StatsD](http://codeascraft.com/2011/02/15/measure-anything-measure-everything/) and then graphed using [graphite](http://graphite.wikidot.com/), [graphene](http://jondot.github.io/graphene/) or any other tool of your choice. For instance:
@@ -499,6 +506,18 @@ $ phantomas http://app.net/start -R elasticsearch:es.app.net::app:phantomas_metr
 ```
 
 Note: as ``<port>`` option was skipped a default value will be used (``9200``).
+
+#### Send metrics to AWS CloudWatch
+
+##### Parameters
+
+ * --aws-access-key-id  : a valid aws access key id with CloudWatch rights
+ * --aws-secret-key : a corresponding secret key
+ * --aws-region us-east-1 : aws server region (default to 'us-east-1')
+ * --aws-cloudwatch-api-version : aws CloudWatch Api version (default to 'latest')
+ * --aws-cloudwatch-namespace : CloudWatch metric namespace where all the metrics will be saved (default to phantomas)
+
+Or by using reporter options (``<AWSAccessKeyId>:<AWSSecretKey>:<AWSRegion>:<CloudWatchApiVersion>:<CloudWatchNameSpace>``)
 
 ## Engines
 

--- a/README.md
+++ b/README.md
@@ -468,8 +468,7 @@ This will omit CSV headers row and add current timestamp as the first column, so
 ##### StatsD
 * ``<host>:<port>:<prefix>`` - shorthand for ``--statsd-host``, ``--statsd-port`` and ``--statsd-prefix`` (you don't need to provide all three options)
 
-
-##### Aws CloudWatch
+##### AWS CloudWatch
 * ``<accessKeyId>:<secretKey>:<region>:<apiVersion>:<namespace>`` - shorthand for ``--aws-access-key-id``, ``--aws-secret-key``, ``--aws-region``, ``--aws-cloudwatch-api-version`` and ``--aws-cloudwatch-namespace`` (only AccessKeyId and SecretKey are required)
 
 #### StatsD integration

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ansistyles": "~0.1.0",
     "ascii-table": "0.0.8",
     "async": "^1.2.0",
+    "aws-sdk": "^2.2.33",
     "csv-string": "^2.3.0",
     "debug": "^2.2.0",
     "elasticsearch": "^4.1.0",

--- a/reporters/cloudwatch.js
+++ b/reporters/cloudwatch.js
@@ -1,0 +1,102 @@
+/**
+ * Reporter for storing data in AWS CloudWatch
+ * --reporter cloudwatch
+ * --aws-access-key-id null
+ * --aws-secret-key
+ * --aws-region us-east-1
+ * --aws-cloudwatch-api-version latest
+ * --aws-cloudwatch-namespace phantomas
+ *
+ * Options:
+ *  <AWSAccessKeyId>:<AWSSecretKey>:<AWSRegion>:<CloudWatchApiVersion>:<CloudWatchNameSpace>
+ */
+'use strict';
+
+var AWS = require('aws-sdk'),
+	Q = require('q');
+
+var CLOUDWATCH_METRICS_DATA_CHUNK_SIZE = 20;
+
+function _formatNumericalMetricsInChunksForCW(metricData) {
+	var chunks = [];
+
+	var formattedData = Object.keys(metricData)
+		.filter(function(key) {
+			return typeof metricData[key] == 'number';
+		})
+		.map(function(key) {
+			return {
+				MetricName: key,
+				Value: metricData[key]
+			};
+		});
+
+	while (formattedData.length > 0)
+		chunks.push(formattedData.splice(0, CLOUDWATCH_METRICS_DATA_CHUNK_SIZE));
+
+	return chunks;
+}
+
+function _pushChunkToCW(cloudwatch, namespace, cloudWatchMetricsData) {
+	var deferred = Q.defer();
+
+	var cloudWatchMetricSet = {
+		Namespace: namespace,
+		MetricData: cloudWatchMetricsData
+	};
+
+	cloudwatch.putMetricData(cloudWatchMetricSet, function(err, data) {
+		if (err) deferred.reject(err)
+		else deferred.resolve(data);
+	});
+
+	return deferred.promise;
+}
+
+module.exports = function(results, reporterOptions, options) {
+	var debug = require('debug')('phantomas:reporter:cloudwatch'),
+		params;
+
+	// -R cloudwatch:<AWSAccessKeyId>:<AWSSecretKey>:<AWSRegion>:<CloudWatchApiVersion>:<CloudWatchNameSpace>
+	if (reporterOptions.length > 0) {
+		options['aws-access-key-id'] = reporterOptions[0];
+		options['aws-secret-key'] = reporterOptions[1];
+		options['aws-region'] = reporterOptions[2];
+		options['aws-cloudwatch-api-version'] = reporterOptions[3];
+		options['aws-cloudwatch-namespace'] = reporterOptions[4];
+	}
+
+	params = {
+		AWSConfigs: {
+			accessKeyId: options['aws-access-key-id'],
+			secretAccessKey: options['aws-secret-key'],
+			region: options['aws-region'] || 'us-east-1',
+			apiVersion: options['aws-cloudwatch-api-version'] || 'latest'
+		},
+		CloudWatchNameSpace: options['aws-cloudwatch-namespace'] || 'phantomas-metrics'
+	};
+
+	debug('Patameters: %j', params);
+
+	// public API
+	return {
+		render: function(done) {
+			var cloudwatch = new AWS.CloudWatch(params.AWSConfigs),
+				metrics = results.getMetrics();
+
+			var cloudWatchMetricsDataChunks = _formatNumericalMetricsInChunksForCW(metrics);
+			var promises = cloudWatchMetricsDataChunks.map(_pushChunkToCW.bind(this, cloudwatch, params.CloudWatchNameSpace));
+
+			Q.all(promises)
+				.then(function(_) {
+					debug('All metrics sent');
+				})
+				.fail(function(err) {
+					debug('Error: %s', err);
+				})
+				.finally(function() {
+					done();
+				});
+		}
+	};
+};


### PR DESCRIPTION
I often use phantomas to push directly to AWS CloudWatch to monitor my performance metrics so I thought it would be a good idea to share it with the community. To me, CloudWatch is a good enough and ready to use reporter.

There is nothing so complex in this pull request, comments are welcome.