### PR TITLE
Wait for stdout flush

### DIFF
--- a/bin/phantomas.js
+++ b/bin/phantomas.js
@@ -231,7 +231,7 @@ async.series(
 			// reporter returned results, otherwise wait for doneFn to be called by reporter
 			if (typeof res !== 'undefined') {
 				process.stdout.write(res);
-				doneFn();
+				process.stdout.on('drain', doneFn); // issue #596
 			} else {
 				debug('Waiting for the results...');
 			}


### PR DESCRIPTION
Long JSON results need time to be fully flushed to `stdout`. Bind to `drain` event before calling `doneFn` callback when `process.stdout.write` returns `false`.

Resolves #596