### PR TITLE
Remove the webkit2 solution

### DIFF
--- a/Troubleshooting.md
+++ b/Troubleshooting.md
@@ -18,5 +18,3 @@ phantomas: (254) Page loading failed
 ```
 
 **Solution**: Try providing ``--ssl-protocol=tlsv1`` or ``--ssl-protocol=any`` option.
-
-**Solution**: Try [running phantomas using PhantomJS 2.0](https://github.com/macbre/phantomas#engines) via ``--engine=webkit2`` option.


### PR DESCRIPTION
As the `webkit2` engine doesn't exist anymore (#602).