### PR TITLE
Added additional information to promise reject function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,10 @@ function phantomas(url, opts, callback) {
 		// either reject or resolve the promise
 		if (code > 250) {
 			debug('Rejecting a promise with %d exit code', code);
-			deferred.reject(code);
+			deferred.reject(code, {
+				json: json,
+				results: results
+			});
 		} else {
 			debug('Resolving a promise with %d exit code', code);
 			deferred.resolve({


### PR DESCRIPTION
Currently when working with promises there is no way to get the results.
This is an issue especially when the error is a timeout where the results may still be valid and useful but currently cannot be handled.