### PR TITLE
Replace .once by .on for metrics consistency after a JS redirection

### DIFF
--- a/modules/domMutations/domMutations.js
+++ b/modules/domMutations/domMutations.js
@@ -14,7 +14,7 @@ exports.module = function(phantomas) {
 	phantomas.setMetric('DOMmutationsRemoves'); // @desc number of <body> node removes
 	phantomas.setMetric('DOMmutationsAttributes'); // @desc number of DOM nodes attributes changes
 
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
 				if ('MutationObserver' in window) {

--- a/modules/domQueries/domQueries.js
+++ b/modules/domQueries/domQueries.js
@@ -18,7 +18,7 @@ exports.module = function(phantomas) {
 	phantomas.setMetric('DOMqueriesAvoidable'); // @desc number of repeated uses of a duplicated query 
 
 	// fake native DOM functions
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
 				function querySpy(type, query, fnName, context, hasNoResults) {

--- a/modules/events/events.js
+++ b/modules/events/events.js
@@ -11,7 +11,7 @@ exports.module = function(phantomas) {
 	phantomas.setMetric('eventsDispatched'); // @desc number of EventTarget.dispatchEvent calls
 	phantomas.setMetric('eventsScrollBound'); // @desc number of scroll event bounds
 
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
 				// spy calls to EventTarget.addEventListener

--- a/modules/jQuery/jQuery.js
+++ b/modules/jQuery/jQuery.js
@@ -23,7 +23,7 @@ exports.module = function(phantomas) {
 	phantomas.setMetric('jQueryDOMWriteReadSwitches'); // @desc number of read operations that follow a series of write operations (will cause repaint and can cause reflow)
 
 	// spy calls to jQuery functions
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
 				// read & write DOM operations (issue #436)

--- a/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
+++ b/modules/javaScriptBottlenecks/javaScriptBottlenecks.js
@@ -22,7 +22,7 @@ exports.module = function(phantomas) {
 		phantomas.log('javaScriptBottlenecks: to spy calls to eval() run phantomas with --spy-eval option');
 	}
 
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function(spyEval) {
 			(function(phantomas) {
 				function report(msg, caller, backtrace, metric) {

--- a/modules/repaints/repaints.js
+++ b/modules/repaints/repaints.js
@@ -13,7 +13,7 @@ exports.module = function(phantomas) {
 	phantomas.setMetric('repaints'); // @desc number of repaints of the current document @gecko
 	phantomas.setMetric('firstPaint'); // @desc time it took to perform the first paint @gecko @unreliable
 
-	phantomas.once('init', function() {
+	phantomas.on('init', function() {
 		phantomas.evaluate(function() {
 			(function(phantomas) {
 				// feature detection


### PR DESCRIPTION
This is a fix for #611.

Should I change the version number of modified modules?

I could not replace the `.once()` function in the `requestsTo` module, because of the `domainsTo` offenders.
Have a look here: https://github.com/macbre/phantomas/blob/devel/modules/requestsTo/requestsTo.js#L23
The offenders for domainsTo will be added twice, but the metrics will be overridden, this is not consistent. There is a need for a `phantomas.resetOffenders()` function here.

But it's ok for me if we decide that performance timings are only measured on the first page and not after the redirection. This is why I didn't modify the `windowPerformance` module neither.