### PR TITLE
Automatically allow main domain when using --allow-domain

### DIFF
--- a/modules/blockDomains/blockDomains.js
+++ b/modules/blockDomains/blockDomains.js
@@ -34,7 +34,7 @@ exports.module = function(phantomas) {
 
 		// match whitelist (--allow-domain)
 		if (allowedDomainsRegExp) {
-			if (allowedDomainsRegExp.test(domain)) {
+			if (allowedDomainsRegExp.test(domain) || domain === ourDomain) {
 				blocked = false;
 			} else {
 				blocked = true;

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -123,6 +123,14 @@
     blockedRequests: 2
     domains: 1
     jsErrors: 0
+# accept main domain in allow-domains
+- url: "/jquery-multiple.html"
+  label: "/jquery-multiple.html (with --allow-domain)"
+  options:
+    "allow-domain": "foo.com"
+  metrics:
+    requests: 2
+    blockedRequests: 2
 # jQuery read & write operations (issue #436)
 - url: "/jquery-reads-writes.html"
   metrics:


### PR DESCRIPTION
Currently, when using the domain blocking option `--allow-domain` (alias the whitelist), the main domain has to be specified, otherwise the test fails with a 254 error.

With this pull request, the main domain is always accepted, even if the user forgets to put it in the whitelist.