### PR TITLE
New metric proposal "synchronousXHR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Only ``plain`` (the default one) and ``json`` reporters are currently supported 
 
 ## Metrics
 
-_Current number of metrics: 135_
+_Current number of metrics: 136_
 
 Units:
 
@@ -182,6 +182,7 @@ Units:
 ### AJAX requests
 
 * ajaxRequests: number of AJAX requests
+* synchronousXHR: number of XMLHttpRequest that are not asynchronous
 
 ### Assets types
 

--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -63,6 +63,12 @@
       "unit": "number",
       "module": "ajaxRequests"
     },
+    "synchronousXHR": {
+      "desc": "number of synchronous XMLHttpRequest",
+      "offenders": true,
+      "unit": "number",
+      "module": "ajaxRequests"
+    },
     "windowAlerts": {
       "desc": "number of calls to window.alert",
       "unit": "number",
@@ -1033,7 +1039,7 @@
       "module": "windowPerformance"
     }
   },
-  "metricsCount": 173,
+  "metricsCount": 174,
   "modulesCount": 35,
-  "version": "1.11.0"
+  "version": "1.14.0"
 }

--- a/modules/ajaxRequests/ajaxRequests.js
+++ b/modules/ajaxRequests/ajaxRequests.js
@@ -3,15 +3,30 @@
  */
 'use strict';
 
-exports.version = '0.2';
+exports.version = '0.3';
 
 exports.module = function(phantomas) {
 	phantomas.setMetric('ajaxRequests'); // @desc number of AJAX requests
+	phantomas.setMetric('synchronousXHR'); // @desc number of synchronous XMLHttpRequest
 
 	phantomas.on('send', function(entry, res) {
 		if (entry.isAjax) {
 			phantomas.incrMetric('ajaxRequests');
 			phantomas.addOffender('ajaxRequests', entry.url);
 		}
+	});
+
+	phantomas.on('init', function() {
+		phantomas.evaluate(function() {
+			(function(phantomas) {
+				phantomas.spy(window.XMLHttpRequest.prototype, 'open', function(result, method, url, async) {
+					if (async === false) {
+						phantomas.incrMetric('synchronousXHR');
+						phantomas.addOffender('synchronousXHR', url);
+						phantomas.log('ajaxRequests: synchronous XMLHttpRequest call to <%s>', url);
+					}
+				}, true);
+			})(window.__phantomas);
+		});
 	});
 };

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -216,3 +216,9 @@
     requests: 2
     htmlCount: 2
     jsErrors: 0
+# synchronous XMLHttpRequest
+- url: "/ajax.html"
+  metrics:
+    ajaxRequests: 2
+    synchronousXHR: 1
+    requestsWithTimeout: 0

--- a/test/webroot/ajax.html
+++ b/test/webroot/ajax.html
@@ -1,9 +1,9 @@
 <script>
 	var asyncXHR = new XMLHttpRequest();
-	asyncXHR.open("GET", "jquery.html", false);
+	asyncXHR.open("GET", "jquery.html", true);
 	asyncXHR.send();
 
 	var SynchronousXHR = new XMLHttpRequest();
-	SynchronousXHR.open("GET", "inline-css.html", true);
+	SynchronousXHR.open("GET", "inline-css.html", false);
 	SynchronousXHR.send();
 </script>

--- a/test/webroot/ajax.html
+++ b/test/webroot/ajax.html
@@ -1,0 +1,9 @@
+<script>
+	var asyncXHR = new XMLHttpRequest();
+	asyncXHR.open("GET", "jquery.html", false);
+	asyncXHR.send();
+
+	var SynchronousXHR = new XMLHttpRequest();
+	SynchronousXHR.open("GET", "inline-css.html", true);
+	SynchronousXHR.send();
+</script>


### PR DESCRIPTION
This metric is meant to count the number of **not asynchronous** XMLHttpRequest (https://github.com/gmetais/YellowLabTools/issues/138).

While adding this metric, I found two problems. The test I added reveals both problems, this is why the Travis tests will break.
1. the `ajaxRequests` metric does not catch all kind of ajax requests, is it broken?
2. synchronous XHR are never marked as received, as you can see in the `requestsWithTimeout` offenders. The reason is because PhantomJS doesn't trigger the `onResourceReceived` event for synchronous XHR calls (https://github.com/ariya/phantomjs/issues/11284).

I will open two new issues. Should I correct the tests so that the new metric can be merged safely?
