### PR TITLE
Quick fix for cookie regression in PhantomJS 2.1

### DIFF
--- a/extensions/cookies/cookies.js
+++ b/extensions/cookies/cookies.js
@@ -4,7 +4,7 @@
 /* global phantom: true */
 'use strict';
 
-exports.version = '1.0';
+exports.version = '1.1';
 
 exports.module = function(phantomas) {
 
@@ -74,7 +74,8 @@ exports.module = function(phantomas) {
 				}
 
 				if (!phantom.addCookie(cookie)) {
-					throw 'PhantomJS could not add cookie: ' + JSON.stringify(cookie);
+					// In PhantomJS 2.1, the addCookie function always returns false (#597).
+					//throw 'PhantomJS could not add cookie: ' + JSON.stringify(cookie);
 				}
 
 				phantomas.log('Cookies: set ' + JSON.stringify(cookie));

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -9,6 +9,8 @@
 
 # DOM operations
 - url: "/dom-operations.html"
+  options:
+    cookie: "bar=foo;domain=url"
   metrics:
     requests: 3
     cssCount: 1


### PR DESCRIPTION
Fixes #597.

A regression in PhantomJS 2.1 (https://github.com/ariya/phantomjs/issues/14047) causes a bug in Phantomas:

The regression makes the `phantom.addCookie()` method always returns `false`. As Phantomas throws an error when `false`, the run fails.

It would be super awesome if this could get into a v1.15.1 :)