### PR TITLE
XMLHttpRequest not being counted in ajaxRequests

### DIFF
--- a/core/modules/requestsMonitor/requestsMonitor.js
+++ b/core/modules/requestsMonitor/requestsMonitor.js
@@ -65,15 +65,6 @@ exports.module = function(phantomas) {
 
 		res.headers.forEach(function(header) {
 			entry.requestHeaders[header.name] = header.value;
-
-			switch (header.name.toLowerCase()) {
-				// AJAX requests
-				case 'x-requested-with':
-					if (header.value === 'XMLHttpRequest') {
-						entry.isAjax = true;
-					}
-					break;
-			}
 		});
 
 		parseEntryUrl(entry);

--- a/modules/ajaxRequests/ajaxRequests.js
+++ b/modules/ajaxRequests/ajaxRequests.js
@@ -1,6 +1,7 @@
 /**
  * Analyzes AJAX requests
  */
+/* global window: true */
 'use strict';
 
 exports.version = '0.2';
@@ -8,10 +9,14 @@ exports.version = '0.2';
 exports.module = function(phantomas) {
 	phantomas.setMetric('ajaxRequests'); // @desc number of AJAX requests
 
-	phantomas.on('send', function(entry, res) {
-		if (entry.isAjax) {
-			phantomas.incrMetric('ajaxRequests');
-			phantomas.addOffender('ajaxRequests', entry.url);
-		}
+	phantomas.on('init', function() {
+		phantomas.evaluate(function() {
+			(function(phantomas) {
+				phantomas.spy(window.XMLHttpRequest.prototype, 'open', function(result, method, url, async) {
+					phantomas.incrMetric('ajaxRequests');
+					phantomas.addOffender('ajaxRequests', '<%s> [%s]', url, method);
+				}, true);
+			})(window.__phantomas);
+		});
 	});
 };

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -218,3 +218,8 @@
     requests: 2
     htmlCount: 2
     jsErrors: 0
+# AJAX requests (#622)
+- url: "/jquery-ajax.html"
+  metrics:
+    requests: 4
+    ajaxRequests: 2

--- a/test/webroot/jquery-ajax.html
+++ b/test/webroot/jquery-ajax.html
@@ -1,0 +1,15 @@
+<body>
+	<script src="/static/jquery-2.1.1.min.js"></script>
+	<script>
+		console.log('$.get');
+
+		$.get('/static/style.css', function() {
+			console.log('Ajax: done');
+		});
+
+		console.log('XMLHttpRequest');
+		var xhr = new XMLHttpRequest();
+		xhr.open("GET", "/static/style.css", true);
+		xhr.send();
+	</script>
+</body>


### PR DESCRIPTION
Resolves #619 and uses code snippets from #618 by @gmetais 

```
Offenders for ajaxRequests (2):
 * </static/style.css> [GET]
 * </static/style.css> [GET]
```

Report AJAX request method in offenders and get rid of `isAjax` custom field.