### PR TITLE
Updated reject promise to return a single argument

### DIFF
--- a/examples/promise.js
+++ b/examples/promise.js
@@ -25,9 +25,9 @@ then(function(res) {
 	console.log('Number of requests: %d', res.results.getMetric('requests'));
 	console.log('Failed asserts: %j', res.results.getFailedAsserts());
 }).
-fail(function(code) {
-	console.log('Exit code #%d', code);
-	process.exit(code);
+fail(function(res) {
+	console.log('Exit code #%d', res.code);
+	process.exit(res.code);
 }).
 progress(function(progress) {
 	console.log('Loading progress: %d%', progress * 100);

--- a/examples/screenshot.js
+++ b/examples/screenshot.js
@@ -27,9 +27,9 @@ run.
 then(function(res) {
 	console.log('Done with exit code: %d', res.code);
 }).
-fail(function(code) {
-	console.log('Exit code #%d', code);
-	process.exit(code);
+fail(function(res) {
+	console.log('Exit code #%d', res.code);
+	process.exit(res.code);
 }).
 progress(function(progress) {
 	console.log('Loading progress: %d%', progress * 100);

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,8 @@ function phantomas(url, opts, callback) {
 		// either reject or resolve the promise
 		if (code > 250) {
 			debug('Rejecting a promise with %d exit code', code);
-			deferred.reject(code, {
+			deferred.reject({
+				code: code,
 				json: json,
 				results: results
 			});

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -67,8 +67,8 @@ vows.describe('CommonJS module').addBatch({
 				timeout: 1
 			}).then(
 				function() {},
-				function(code, json, results) {
-					this.callback(null, code);
+				function(res) {
+					this.callback(null, res.code);
 				}.bind(this)
 			);
 		},


### PR DESCRIPTION
Q only returns the first argument from a promise so the extra arguments added in my previous pull-request are actually being dropped.

Follows on from my previous pull-request https://github.com/macbre/phantomas/pull/609 but unfortunately this is probably a major version bump.