### PR TITLE
Analyze-css failing without incrementing cssParsingErrors

### DIFF
--- a/core/phantomas.js
+++ b/core/phantomas.js
@@ -852,9 +852,10 @@ phantomas.prototype = {
 				var result = stderr !== "" ? stderr : stdout;
 
 				if (err || stderr) {
-					self.log('runScript: pid #%d failed - %s (took %d ms)!', pid, (err || stderr || 'unknown error').trim(), time);
+					var errMessage = (err || stderr || 'unknown error').trim();
+					self.log('runScript: pid #%d failed - %s (took %d ms)!', pid, errMessage, time);
 
-					callback(err, result);
+					callback(errMessage, result);
 
 					done();
 					return;

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -94,7 +94,7 @@ exports.module = function(phantomas) {
 						offender += ' (analyzeCss output error)';
 					}
 				} else { // Error string returned (stderror)
-					if (err.indexOf('CSS parsing failed') > 0) {
+					if (err.indexOf('CSS parsing failed') > 0 || err.indexOf('is an invalid expression') > 0) {
 						offender += ' (' + err.trim() + ')';
 					} else if (err.indexOf('Empty CSS was provided') > 0) {
 						offender += ' (Empty CSS was provided)';


### PR DESCRIPTION
I have a case where analyze-css fails on a file. This is what I see in verbose mode:
```
19:20:20.075 runScript: pid #11495 failed - Error: margin-bottom: 20px; #store-locator-bg is an invalid expression (took 16977 ms)!
```

This is normal because the CSS syntax is wrong, the `margin-bottom` below is not attached to any rule:
```css
@media (max-width:1080px) {
    margin-bottom: 20px;
    #store-locator-bg {
        overflow:hidden;
    }
}
```

The problem is that it doesn't appear in the `cssParsingErrors` metric.

It looks like the error gets stucked in the `runScript` method. It sends `err` to the callback but never sends `stderr`. Have a look here: https://github.com/macbre/phantomas/blob/devel/core/phantomas.js#L857

This fix makes the error appear in `cssParsingErrors`. Here is what the offender looks like now:
```
"cssParsingErrors": [
    "<https://www.domain.com/style.css> (Error: margin-bottom: 20px; #store-locator-bg is an invalid expression)"
],
```