### PR TITLE
make PhantomJS and SlimerJS optionalDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ PhantomJS-based modular web performance metrics collector. And why phantomas? We
 ## Requirements
 
 * [NodeJS](http://nodejs.org)
-* [PhantomJS 1.9+](http://phantomjs.org/)
+* [NPM](https://www.npmjs.com/) 3+
 
 ## Installation
 
 ```
-npm install --global phantomas
+npm install --global --no-optional phantomas phantomjs-prebuilt@^2.1.5
 ```
 
 > This will install the latest version of PhantomJS and add a symlink called ``phantomas`` (pointing to ``./bin/phantomas.js``) to your system's ``PATH``
@@ -522,7 +522,7 @@ You can choose the engine by using either:
 
 ### PhantomJS
 
-All required binaries are installed by npm. No extra work needed here :)
+All required binaries have already been installed by npm. No extra work needed here :)
 
 ### SlimerJS
 
@@ -530,6 +530,12 @@ In order to use SlimerJS install the following Debian/Ubuntu packages:
 
 ```
 sudo aptitude install xvfb libasound2 libgtk2.0-0
+```
+
+You will also need to install the module:
+
+```bash
+npm install --global slimerjs@^0.906.1
 ```
 
 ## For developers

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "node-statsd": "0.1.1",
     "node-uuid": "~1.4.1",
     "optimist": "0.6.x",
-    "phantomjs-prebuilt": "^2.1.5",
     "progress": "~1.1.4",
     "q": "^1.4.1",
-    "slimerjs": "^0.906.1",
     "tap-producer-macbre": "0.0.3",
     "travis-fold": ">=0.1.2"
   },
@@ -49,7 +47,10 @@
     "mockery": "^1.4.0",
     "vows": "^0.7.0"
   },
-  "optionalDependencies": {},
+  "optionalDependencies": {
+    "phantomjs-prebuilt": "^2.1.5",
+    "slimerjs": "^0.906.1"
+  },
   "bin": "./bin/phantomas.js",
   "preferGlobal": true,
   "scripts": {


### PR DESCRIPTION
Before, even though only one of the engines would be used, both were installed, causing extra setup time/hassle. This makes both packages [`optionalDependencies`](https://docs.npmjs.com/files/package.json#optionaldependencies), so only one or both can be installed, as desired. I didn't check if there's anything special that needs to be done for the Python package, so might want to verify that's still ok.

Thanks!