### PR TITLE
Fix cache detection: max-age should overtake expires

### DIFF
--- a/modules/caching/caching.js
+++ b/modules/caching/caching.js
@@ -41,8 +41,10 @@ exports.module = function(phantomas) {
 				case 'x-pass-cache-control':
 					phantomas.incrMetric('oldCachingHeaders'); // @desc number of responses with old, HTTP 1.0 caching headers (Expires and Pragma)
 					phantomas.addOffender('oldCachingHeaders', url + ' - ' + headerName + ': ' + value);
-					headerDate = Date.parse(value);
-					if (headerDate) ttl = Math.round((headerDate - now) / 1000);
+					if (ttl === false) {
+						headerDate = Date.parse(value);
+						if (headerDate) ttl = Math.round((headerDate - now) / 1000);
+					}
 					break;
 			}
 		}


### PR DESCRIPTION
When both `Cache-Control: max-age=` and `Expires` headers are set in response headers, browsers use the `max-age` one.

Currently, Phantomas uses the last declared one in the headers. So this pull-request prevents the `Expires` to override `max-age`.