### PR TITLE
fix simple-queue by enforcing only one done() call per push

### DIFF
--- a/lib/simple-queue.js
+++ b/lib/simple-queue.js
@@ -34,9 +34,13 @@ function queue() {
 
 			// pass an anonymous function to the callback
 			// call it to mark a job as done
+			var called = false;
 			fn(function() {
-				remaining--;
-				postCheck();
+				if (!called) {
+					called = true;
+					remaining--;
+					postCheck();
+				}
 			});
 
 			return this;

--- a/test/simple-queue-test.js
+++ b/test/simple-queue-test.js
@@ -110,6 +110,32 @@ vows.describe('simple-queue').addBatch({
 		'should be completed when all jobs are done': function(err, called) {
 			assert.equal(called, 3);
 		}
+	},
+	'push() + multiple calls of the same done()': {
+		topic: function() {
+			var q = new Queue(),
+				callbackOneIsCalled = false,
+				callbackTwoIsCalled = false;
+
+
+			q.push(function(done) {
+				callbackOneIsCalled = true;
+				done();
+				done();
+				done();
+			}).
+			push(function(done) {
+				callbackTwoIsCalled = true;
+				done();
+			}).
+			done(function() {
+				this.callback(null, callbackOneIsCalled, callbackTwoIsCalled);
+			}, this);
+		},
+		'should call both callbacks, even though the first callback calls done() multiple times': function(err, callbackOneIsCalled, callbackTwoIsCalled) {
+			assert.equal(callbackOneIsCalled, true);
+			assert.equal(callbackTwoIsCalled, true);
+		}
 	}
 
 }).export(module);


### PR DESCRIPTION
This fixes a bug where calling the `done()` function multiple times within a single `push()` will keep advancing the queue, and cause it to skip over the other `push()` functions. 

I encountered this bug while trying to use the `post-load-delay` function. Another part of the code was calling `done()` multiple times, so phantomas wasn't waiting for the postLoadDelay's `done()` function to be invoked before exiting. 