### PR TITLE
Drop support for Node v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 6
   - 5
   - 4
-  - 0.12
 sudo: false
 before_script:
   - sh test/server-start.sh &

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PhantomJS-based modular web performance metrics collector. And why phantomas? We
 
 ## Requirements
 
-* [NodeJS](http://nodejs.org)
+* [NodeJS](http://nodejs.org) 4+
 * [NPM](https://www.npmjs.com/) 3+
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=0.10"
+    "node": ">=4.0"
   },
   "dependencies": {
     "analyze-css": "^0.12.3",


### PR DESCRIPTION
According to https://github.com/nodejs/LTS#lts-schedule v0.12 release support will end 2016-12-31