### PR TITLE
Allow .yml files to be treated as YAML

### DIFF
--- a/lib/optimist-config-file.js
+++ b/lib/optimist-config-file.js
@@ -25,7 +25,7 @@ function parseConfigFile(configFileName) {
 	}
 
 	// JSON or YAML?
-	configMode = /\.yaml$/.test(configFileName) ? 'YAML' : 'JSON';
+	configMode = /\.ya?ml$/.test(configFileName) ? 'YAML' : 'JSON';
 
 	// parse it
 	try {


### PR DESCRIPTION
Hey!
A lot of YAML these days comes in .yml files rather than .yaml.  This has tripped me up a few times working with Phantomas.  How about allowing .yml to be used as well? 