### PR TITLE
Use uuid instead of node-uuid

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,10 @@ var debug = require('debug')('phantomas'),
  */
 function getTmpDir() {
 	var tmpdir = require('os').tmpdir(),
-		uuid = require('node-uuid').v4();
+		uuidV4 = require('uuid/v4');
 
 	// example: /tmp/phantomas/58aea8b5-2c97-48ee-9885-fcd81d38561f/
-	return tmpdir + '/phantomas/' + uuid + '/';
+	return tmpdir + '/phantomas/' + uuidV4() + '/';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "debug": "^2.6.8",
     "js-yaml": "^3.8.4",
     "node-statsd": "0.1.1",
-    "node-uuid": "~1.4.8",
     "optimist": "^0.6.1",
     "optimist-config-file": "^1.0.1",
     "progress": "~2.0.0",
     "q": "^1.5.0",
     "tap-producer-macbre": "0.0.3",
-    "travis-fold": ">=0.1.2"
+    "travis-fold": ">=0.1.2",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "glob": "^7.1.2",


### PR DESCRIPTION
npm WARN deprecated node-uuid@1.4.8: Use uuid module instead

Resolves #691