### PR TITLE
analyzeCss: improve handling of inline <style> tags with unusual "type" attribute values

### DIFF
--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -185,10 +185,17 @@ exports.module = function(phantomas) {
 				phantomas.spyEnabled(false, 'looking for inline styles');
 
 				var styles = document.getElementsByTagName('style'),
-					content = [];
+					content = [],
+					type;
 
 				for (var i = 0, len = styles.length; i < len; i++) {
-					content.push(styles[i].textContent);
+					type = styles[i].getAttribute('type') || 'text/css'; // ignore inline <style> tags with type different than text/css (issue #694)
+
+					if (type === 'text/css') {
+						content.push(styles[i].textContent);
+					} else {
+						phantomas.log('analyzeCss: inline <style> tag found with type="%s", ignoring...', type);
+					}
 				}
 
 				phantomas.spyEnabled(true);

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -67,15 +67,15 @@
   metrics:
     requests: 1
   exitCode: 1 # one assert not met
-# inline styles (#397)
+# inline styles (#397 / #694)
 - url: "/inline-css.html"
   options:
     "analyze-css": true
   metrics:
     requests: 2
-    cssParsingErrors: 0
-    cssInlineStyles: 2
-    cssLength: 106
+    cssParsingErrors: 1
+    cssInlineStyles: 3
+    cssLength: 172
     cssRules: 3
     cssImportants: 1
     DOMqueries: 0

--- a/test/webroot/inline-css.html
+++ b/test/webroot/inline-css.html
@@ -12,5 +12,9 @@
 			color: red !important;
 		}
 	</style>
+	<style>
+		this will not parse correctly as CSS (and should be reported)
+	</style>
+	<style type="junk">do not complain about this</style>
 	<h1>foo</h1>
 </body>


### PR DESCRIPTION
Resolves #694

```
15:19:02.838 analyzeCss: inline <style> tag found with type="junk", ignoring...
```