### PR TITLE
Added support for film-strip-zoom-factor as an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ url: "https://${ENV:-prod}.super-fast-app.io"
 * `--film-strip` register film strip when page is loading **experimental**
 * `--film-strip-dir=[dir path]` folder path to output film strip (default is ``./filmstrip`` directory)
 * `--film-strip-prefix` film strip files name prefix (defaults to ``screenshot``)
+* `--film-strip-zoom-factor` film strip zoom factor (defaults to ``0.5``)
 * `--page-source` save page source to file **experimental**
 * `--page-source-dir=[dir path]` folder path to output page source (default is ``./html`` directory) **experimental**
 * `--assert-[metric-name]=value` assert that given metric should be less or equal the value

--- a/extensions/filmStrip/filmStrip.js
+++ b/extensions/filmStrip/filmStrip.js
@@ -25,7 +25,7 @@ exports.module = function(phantomas) {
 	var filmStripOutputDir = phantomas.getParam('film-strip-dir', 'filmstrip', 'string').replace(/\/+$/, ''),
 		filmStripPrefix = phantomas.getParam('film-strip-prefix', 'screenshot', 'string').replace(/[^a-z0-9\-]+/ig, '-');
 
-	var zoomFactor = 0.5;
+	var zoomFactor = phantomas.getParam('film-strip-zoom-factor', 0.5);
 	phantomas.setZoom(zoomFactor);
 
 	phantomas.log('filmStrip: film strip will be stored as %s/%s-*.png files (zoom: %d)', filmStripOutputDir, filmStripPrefix, zoomFactor);


### PR DESCRIPTION
This PR adds support for a `--film-strip-zoom-factor=x` optional parameter.

This is a fix for #501.