### PR TITLE
Fixed strict warning in scope.js

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -252,7 +252,7 @@
 			});
 
 			window.__defineGetter__(varName, function() {
-				return spiedGlobals[varName];
+				return spiedGlobals[varName] || undefined;
 			});
 
 		}


### PR DESCRIPTION
Simple fix for slimerjs, and new gecko engine.
This line gave me undefined errors, and messed up the output of slimejs