### PR TITLE
Browser.close - check if there is a browser to call close() on

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -246,7 +246,7 @@ Browser.prototype.visit = (url, waitUntil, timeout) => {
 
 // we're done
 Browser.prototype.close = async () => {
-    await this.browser.close();
+    if (this.browser) await this.browser.close();
     this.events.emit('close'); // @desc Chromium has been closed
     debug('Browser closed');
 };


### PR DESCRIPTION
```
2020-08-06T22:58:27.9614980Z (node:2699) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
```