### PR TITLE
Use nginx to make integration tests more deterministic

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,8 +18,5 @@ jobs:
     - name: Run tests inside the Docker container
       run: |
         ./test/server-start.sh &
-        sleep 5
-        docker ps
-        curl -svo /dev/null 0.0.0.0:8888
 
         docker run --network=host ${{ github.repository }} npm t

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,6 +17,6 @@ jobs:
 
     - name: Run tests inside the Docker container
       run: |
-        ./test/server-start.sh &
+        ./test/server-start.sh
 
         docker run --network=host ${{ github.repository }} npm t

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -17,4 +17,9 @@ jobs:
 
     - name: Run tests inside the Docker container
       run: |
-        docker run ${{ github.repository }} ./run_tests.sh
+        ./test/server-start.sh &
+        sleep 5
+        docker ps
+        curl -svo /dev/null 0.0.0.0:8888
+
+        docker run --network=host ${{ github.repository }} npm t

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run tests
       run: |
-        ./test/server-start.sh &
+        ./test/server-start.sh
 
         npm test
         npm run-script lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,6 @@ jobs:
     - name: Run tests
       run: |
         ./test/server-start.sh &
-        sleep 5
-        docker ps
-        curl -svo /dev/null 0.0.0.0:8888
 
         npm test
         npm run-script lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Run tests
       run: |
-        docker run --detach --rm -p 0.0.0.0:8888:8888 -v "$PWD":/app -w /app node:12-alpine ./test/server-start.sh
+        ./test/server-start.sh &
         sleep 5
         docker ps
         curl -svo /dev/null 0.0.0.0:8888

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,12 +196,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
-    "basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
-      "dev": true
-    },
     "bl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -341,12 +335,6 @@
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
       }
-    },
-    "corser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-      "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
-      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -596,12 +584,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
-      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-      "dev": true
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -701,12 +683,6 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
-    "follow-redirects": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
-      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
-      "dev": true
-    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -768,23 +744,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true
-    },
-    "http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "requires": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      }
-    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -793,106 +752,6 @@
         "@tootallnate/once": "1",
         "agent-base": "6",
         "debug": "4"
-      }
-    },
-    "http-server": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
-      "integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
-      "dev": true,
-      "requires": {
-        "basic-auth": "^1.0.3",
-        "colors": "^1.4.0",
-        "corser": "^2.0.1",
-        "ecstatic": "^3.3.2",
-        "http-proxy": "^1.18.0",
-        "minimist": "^1.2.5",
-        "opener": "^1.5.1",
-        "portfinder": "^1.0.25",
-        "secure-compare": "3.0.1",
-        "union": "~0.5.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ecstatic": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
-          "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
-          "dev": true,
-          "requires": {
-            "he": "^1.1.1",
-            "mime": "^1.6.0",
-            "minimist": "^1.1.0",
-            "url-join": "^2.0.5"
-          }
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "opener": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
-          "dev": true
-        },
-        "portfinder": {
-          "version": "1.0.28",
-          "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-          "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.2",
-            "debug": "^3.1.1",
-            "mkdirp": "^0.5.5"
-          }
-        },
-        "qs": {
-          "version": "6.9.4",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-          "dev": true
-        },
-        "union": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-          "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
-          "dev": true,
-          "requires": {
-            "qs": "^6.4.0"
-          }
-        }
       }
     },
     "https-proxy-agent": {
@@ -1342,12 +1201,6 @@
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1366,12 +1219,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "secure-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
-      "dev": true
     },
     "semver": {
       "version": "7.3.2",
@@ -1578,12 +1425,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
-      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "eslint": "^7.6.0",
     "glob": "^7.1.6",
-    "http-server": "^0.12.3",
     "js-beautify": "^1.11.0",
     "mockery": "^2.0.0",
     "vows": "^0.8.3"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -514,12 +514,12 @@
     biggestResponse: 856
   offenders:
     requests:
-      - { url: 'http://127.0.0.1:8888/headers.html', type: 'html', size: 895 }
+      - { url: 'http://127.0.0.1:8888/headers.html', type: 'html', size: 856 }
       - { url: 'http://127.0.0.1:8888/static/blank.gif', type: 'image', size: 342 }
     smallestResponse:
       - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
     biggestResponse:
-      - { url: 'http://127.0.0.1:8888/headers.html', size: 895 }
+      - { url: 'http://127.0.0.1:8888/headers.html', size: 856 }
 
 # iframes
 - url: "/iframe.html"
@@ -538,8 +538,8 @@
     otherCount: 1  # with HTTP 404 response we can't determine the type
   offenders:
     requests:
-      - { url: 'http://127.0.0.1:8888/not-found.html', type: 'html', size: 362 }
-      - { url: 'http://127.0.0.1:8888/not_found/foo.js', type: 'other', size: 130 }
+      - { url: 'http://127.0.0.1:8888/not-found.html', type: 'html', size: 380 }
+      - { url: 'http://127.0.0.1:8888/not_found/foo.js', type: 'html', size: 177 }
     notFound:
       - 'http://127.0.0.1:8888/not_found/foo.js'
 
@@ -564,12 +564,12 @@
     ajaxRequests: 1
     consoleMessages: 2
     jsonCount: 1
-    jsonSize: 333
+    jsonSize: 345
   offenders:
     ajaxRequests:
       - { url: '/foo.json', method: 'GET' }
     jsonCount:
-      - { url: 'http://127.0.0.1:8888/foo.json', size: 333 }
+      - { url: 'http://127.0.0.1:8888/foo.json', size: 345 }
     consoleMessages:
       - 'log:["Ajax fetched"]'
       - 'log:["Page fully loaded"]'
@@ -591,7 +591,7 @@
     imageCount: 1
   offenders:
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20679 }
+      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20690 }
     consoleMessages:
       - 'log:["Lazy loading /static/mdn.png"]'
 
@@ -646,9 +646,6 @@
       - { domain: '127.0.0.1', requests: 1 }
       - { domain: 'fonts.googleapis.com', requests: 1 }
       - { domain: 'fonts.gstatic.com', requests: 1 }
-    assetsNotGzipped:
-      # CSS response is compressed using "brotli"
-      - { url: 'http://127.0.0.1:8888/https-fonts.html', contentType: 'text/html' }
 
 # staticAssets
 - url: "/assets.html"
@@ -656,9 +653,9 @@
     assetsWithQueryString:
       - { url: 'http://127.0.0.1:8888/static/mdn.png?cb=123', contentType: 'image/png' }
     smallImages:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 330 }
+      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
     smallCssFiles:
-      - { url: 'http://127.0.0.1:8888/static/style.css', size: 308 }
+      - { url: 'http://127.0.0.1:8888/static/style.css', size: 320 }
 
 # authentication
 - url: "https://httpbin.org/basic-auth/foo/bar"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -380,8 +380,6 @@
     imageSize: 342
     requests: 2
   offenders:
-    htmlCount:
-      - { url: 'http://127.0.0.1:8888/after-onload.html', size: 582 }
     imageCount:
       - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
 
@@ -391,12 +389,12 @@
     "wait-for-network-idle": true
   metrics:
     imageCount: 2
-    imageSize: 210032
+    imageSize: 21032
     requests: 3
   offenders:
     imageCount:
       - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20679 }
+      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20690 }
 
 # lazy-loadable-images.html (#494)
 - url: "/lazy-loadable-images.html"
@@ -488,10 +486,10 @@
 - url: "/headers.html"
   metrics:
     requests: 2
-    headersCount: 20
+    headersCount: 24
     headersSentCount: 4
-    headersRecvCount: 16
-    headersRecvSize: 540
+    headersRecvCount: 20
+    headersRecvSize: 571
 #    headersBiggerThanContent: 1
 #  offenders:
 #    headersBiggerThanContent:
@@ -504,24 +502,24 @@
     cachingTooShort: 1
   offenders:
     cachingTooShort:
-     - { url: 'http://127.0.0.1:8888/static/mdn.png', ttl: 84600 }
+     - { url: 'http://127.0.0.1:8888/static/mdn.png', ttl: 86400 }
 
 # requestsStats
 - url: "/headers.html"
   metrics:
     requests: 2
     bodySize: 1065  # uncompressed content of all responses (without headers)
-    contentLength: 1643 # transfered bytes
-    smallestResponse: 330  # headers + body size
-    biggestResponse: 1313
+    contentLength: 1198 # transfered bytes
+    smallestResponse: 342  # headers + body size
+    biggestResponse: 856
   offenders:
     requests:
-      - { url: 'http://127.0.0.1:8888/headers.html', type: 'html', size: 1313 }
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', type: 'image', size: 330 }
+      - { url: 'http://127.0.0.1:8888/headers.html', type: 'html', size: 895 }
+      - { url: 'http://127.0.0.1:8888/static/blank.gif', type: 'image', size: 342 }
     smallestResponse:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 330 }
+      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
     biggestResponse:
-      - { url: 'http://127.0.0.1:8888/headers.html', size: 1313 }
+      - { url: 'http://127.0.0.1:8888/headers.html', size: 895 }
 
 # iframes
 - url: "/iframe.html"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -13,13 +13,13 @@
     cookie: "bar=foo;domain=url"
   metrics:
     requests: 3
-    gzipRequests: 1
+    gzipRequests: 2
     htmlCount: 1
-    htmlSize: 2385
+    htmlSize: 946
     cssCount: 1
-    cssSize: 308
+    cssSize: 320
     jsCount: 1
-    jsSize: 29730  # compressed
+    jsSize: 29734  # compressed
     domains: 1
     DOMqueries: 20
     DOMqueriesById: 6
@@ -33,13 +33,14 @@
 
   offenders:
     gzipRequests:
-      - {url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', bodySize: 84245, transferedSize: 29730 }
+      - {url: 'http://127.0.0.1:8888/dom-operations.html', bodySize: 2094, transferedSize: 946 }
+      - {url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', bodySize: 84245, transferedSize: 29734 }
     htmlCount:
-      - { url: 'http://127.0.0.1:8888/dom-operations.html', size: 2385 }
+      - { url: 'http://127.0.0.1:8888/dom-operations.html', size: 946 }
     cssCount:
-      - { url: 'http://127.0.0.1:8888/static/style.css', size: 308 }
+      - { url: 'http://127.0.0.1:8888/static/style.css', size: 320 }
     jsCount:
-      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', size: 29730 }
+      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', size: 29734 }
 
     DOMqueriesById:
       - { id: 'foo', node: '#document' }
@@ -174,7 +175,7 @@
 # jQuery and events (#440 / #451)
 - url: "/jquery.html"
   metrics:
-    gzipRequests: 1
+    gzipRequests: 2
     jQueryVersion: "2.1.1"
     jQueryOnDOMReadyFunctions: 1
     jQueryWindowOnLoadFunctions: 1
@@ -185,7 +186,8 @@
     eventsScrollBound: 2
   offenders:
     gzipRequests:
-      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', transferedSize: 29730, bodySize: 84245 }
+      - { url: 'http://127.0.0.1:8888/jquery.html', transferedSize: 761, bodySize: 1027 }
+      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', transferedSize: 29734, bodySize: 84245 }
     eventsDispatched:
       - { eventType: 'click', path: 'body > div#foo > span.bar' }
     eventsBound:
@@ -375,13 +377,13 @@
   label: "/after-onload.html"
   metrics:
     imageCount: 1
-    imageSize: 330
+    imageSize: 342
     requests: 2
   offenders:
     htmlCount:
-      - { url: 'http://127.0.0.1:8888/after-onload.html', size: 658 }
+      - { url: 'http://127.0.0.1:8888/after-onload.html', size: 582 }
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 330 }
+      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
 
 - url: "/after-onload.html"
   label: "/after-onload.html (with --wait-for-network-idle)"
@@ -389,11 +391,11 @@
     "wait-for-network-idle": true
   metrics:
     imageCount: 2
-    imageSize: 21009
+    imageSize: 210032
     requests: 3
   offenders:
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 330 }
+      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
       - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20679 }
 
 # lazy-loadable-images.html (#494)

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -535,7 +535,6 @@
   metrics:
     requests: 2
     notFound: 1
-    otherCount: 1  # with HTTP 404 response we can't determine the type
   offenders:
     requests:
       - { url: 'http://127.0.0.1:8888/not-found.html', type: 'html', size: 380 }

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.2'
+
+services:
+  nginx:
+    image: macbre/nginx-brotli:1.18.0
+    ports:
+      - "8888:80"
+    volumes:
+      # see nginx-static.conf
+      - './webroot:/static'
+      - './nginx-static.conf:/etc/nginx/conf.d/nginx-static.conf'

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -1,0 +1,16 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    server_tokens off;
+
+    location / {
+        root   /static;
+        autoindex on;
+
+        gzip_static on;
+        brotli_static on;
+
+        expires 1d;
+    }
+}

--- a/test/server-start.sh
+++ b/test/server-start.sh
@@ -2,3 +2,9 @@ DIR=`dirname $0`
 
 cd $DIR
 docker-compose -f nginx-docker-compose.yaml up
+
+# wait for it...
+sleep 5
+docker ps
+
+curl -svo /dev/null 0.0.0.0:8888 --compressed

--- a/test/server-start.sh
+++ b/test/server-start.sh
@@ -1,7 +1,7 @@
 DIR=`dirname $0`
 
 cd $DIR
-docker-compose -f nginx-docker-compose.yaml up
+docker-compose -f nginx-docker-compose.yaml up -d
 
 # wait for it...
 sleep 5

--- a/test/server-start.sh
+++ b/test/server-start.sh
@@ -1,5 +1,1 @@
-PORT=8888
-DIR=`dirname $0`
-
-$DIR/../node_modules/.bin/http-server $DIR/webroot -p $PORT -c 84600 --gzip --log-ip
-
+docker-compose -f nginx-docker-compose.yaml up

--- a/test/server-start.sh
+++ b/test/server-start.sh
@@ -1,1 +1,4 @@
+DIR=`dirname $0`
+
+cd $DIR
 docker-compose -f nginx-docker-compose.yaml up


### PR DESCRIPTION
`http-server` depends on the Node.js `http` module that changes from version to version (see `Keep-alive` header - #769 and https://github.com/nodejs/node/pull/34561).

Let's use `nginx` as a lightweight static assets server (with gzip and brotli support). Assertions need to be updated to match the new response details (e.g. `Server` and `ETag` headers format).

## Example

```
< HTTP/1.1 200 OK
< Server: nginx
< Date: Tue, 01 Sep 2020 11:29:00 GMT
< Content-Type: text/html
< Last-Modified: Tue, 01 Sep 2020 10:37:49 GMT
< Transfer-Encoding: chunked
< Connection: keep-alive
< ETag: W/"5f4e247d-1c7"
< Expires: Wed, 02 Sep 2020 11:29:00 GMT
< Cache-Control: max-age=86400
< Content-Encoding: gzip
```