### PR TITLE
Tests: use the latest macbre/nginx-brotli - 1.19.3

### DIFF
--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -339,8 +339,6 @@
     domainsToDomContentLoaded: 2
     requestsToDomComplete: 3
     domainsToDomComplete: 2
-    # test are made using a HTTP server running locally, it should be pretty fast to connect to it
-    performanceTimingDNS: 0
   offenders:
     domainsToDomContentLoaded:
       - { domain: '127.0.0.1', requests: 2 }

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.2'
 
 services:
   nginx:
-    image: macbre/nginx-brotli:1.18.0
+    # https://hub.docker.com/r/macbre/nginx-brotli
+    image: macbre/nginx-brotli:1.19.3
     ports:
       - "8888:80"
     volumes:


### PR DESCRIPTION
https://github.com/macbre/docker-nginx-brotli/pull/14