### PR TITLE
core/scope.js: log window URL and whether it is an iframe

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -327,6 +327,6 @@
   phantomas.log(
     "phantomas page scope initialized for <%s> (is an iframe: %s)",
     window.location.toString(),
-    window.parent == window
+    window.parent !== window
   );
 })(window);

--- a/core/scope.js
+++ b/core/scope.js
@@ -324,5 +324,9 @@
   phantomas.getDOMPath = getDOMPath;
   phantomas.nodeRunner = nodeRunner;
 
-  phantomas.log("phantomas page scope initialized");
+  phantomas.log(
+    "phantomas page scope initialized for <%s> (is an iframe: %s)",
+    window.location.toString(),
+    window.parent == window
+  );
 })(window);


### PR DESCRIPTION
Resolves #792

```
$ DEBUG=phantomas:scope:log ./bin/phantomas.js http://0.0.0.0:8888/iframe.html 2>&1 | grep "page scope"
2020-10-07T14:20:47.350Z phantomas:scope:log phantomas page scope initialized for <http://0.0.0.0:8888/iframe.html> (is an iframe: true)
2020-10-07T14:20:47.351Z phantomas:scope:log domQueries: initializing page scope code
2020-10-07T14:20:47.353Z phantomas:scope:log domQueries: page scope code initialized
2020-10-07T14:20:47.373Z phantomas:scope:log phantomas page scope initialized for <http://0.0.0.0:8888/image-scaling.html> (is an iframe: false)
2020-10-07T14:20:47.373Z phantomas:scope:log domQueries: initializing page scope code
2020-10-07T14:20:47.376Z phantomas:scope:log domQueries: page scope code initialized
```