### PR TITLE
Makes tests crash on unhandled rejections instead of silently ignoring them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,4 @@ jobs:
       run: ./bin/phantomas.js http://127.0.0.1:8888/ --pretty | grep "generator" -A4
 
     - name: Check that bin/phantomas.js handles errors correctly
-      run: |
-        ./bin/phantomas.js http://127.0.0.1:1234/ 2>&1 | grep "net::ERR_CONNECTION_REFUSED at http://127.0.0.1:1234"
-        ./bin/phantomas.js http://127.0.0.1:8888/not_found 2>&1 | grep "Error: Navigation failed because browser has disconnected!"
+      run: ./bin/phantomas.js http://127.0.0.1:1234/ 2>&1 | grep "net::ERR_CONNECTION_REFUSED at http://127.0.0.1:1234"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,6 @@ jobs:
       run: ./bin/phantomas.js http://127.0.0.1:8888/ --pretty | grep "generator" -A4
 
     - name: Check that bin/phantomas.js handles errors correctly
-      run: ./bin/phantomas.js http://127.0.0.1:1234/ 2>&1 | grep "net::ERR_CONNECTION_REFUSED at http://127.0.0.1:1234"
+      run: |
+        ./bin/phantomas.js http://127.0.0.1:1234/ 2>&1 | grep "net::ERR_CONNECTION_REFUSED at http://127.0.0.1:1234"
+        ./bin/phantomas.js http://127.0.0.1:8888/not_found 2>&1 | grep "Error: Navigation failed because browser has disconnected!"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-test/
+test/webroot/
 *.md
 *.yml
 *.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV DOCKERIZED yes
 # Install dependencies
 COPY package.json .
 COPY package-lock.json .
-RUN npm i
+RUN npm ci
 
 # Copy the content of the rest of the repository into a container
 COPY . .

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -290,6 +290,7 @@ Browser.prototype.close = async () => {
     if (this.browser) await this.browser.close();
   } catch (ex) {
     debug("An exception was raised in Browser.prototype.close(): " + ex);
+    throw ex;
   }
 
   this.events.emit("close"); // @desc Chromium has been closed

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -266,10 +266,15 @@ Browser.prototype.visit = (url, waitUntil, timeout) => {
     // while calling page.evaluate()
     this.events.emit("loaded", this.page); // @desc Emitted when the page has been fully loaded
 
-    const metrics = await this.page.metrics();
-    debug("Metrics: %s", JSON.stringify(metrics));
+    try {
+      const metrics = await this.page.metrics();
+      debug("Metrics: %s", JSON.stringify(metrics));
 
-    this.events.emit("metrics", metrics); // @desc Emitted when Chromuim's page.metrics() has been called
+      this.events.emit("metrics", metrics); // @desc Emitted when Chromuim's page.metrics() has been called
+    } catch (ex) {
+      debug("Get metrics failed: " + ex);
+      return reject(ex);
+    }
     resolve();
   });
 };

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -281,12 +281,17 @@ Browser.prototype.visit = (url, waitUntil, timeout) => {
 
 // we're done
 Browser.prototype.close = async () => {
-  // Allow the beforeunload event to be executed
-  // https://github.com/puppeteer/puppeteer/blob/v1.11.0/docs/api.md#pagecloseoptions
-  if (this.page) await this.page.close({ runBeforeUnload: true });
+  try {
+    // Allow the beforeunload event to be executed
+    // https://github.com/puppeteer/puppeteer/blob/v1.11.0/docs/api.md#pagecloseoptions
+    if (this.page) await this.page.close({ runBeforeUnload: true });
 
-  // The page is closed, let's close the browser
-  if (this.browser) await this.browser.close();
+    // The page is closed, let's close the browser
+    if (this.browser) await this.browser.close();
+  } catch (ex) {
+    debug("An exception was raised in Browser.prototype.close(): " + ex);
+  }
+
   this.events.emit("close"); // @desc Chromium has been closed
   debug("Browser closed");
 };

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -788,10 +788,10 @@
       - { url: "http://127.0.0.1:8888/static/style.css", size: 320 }
 
 # authentication
-- url: "https://httpbin.org/basic-auth/foo/bar"
-  label: "httpbin's /basic-auth"
-  # the following promise rejection is expected
-  error: "HTTP response code from <https://httpbin.org/basic-auth/foo/bar> is 401"
+# - url: "https://httpbin.org/basic-auth/foo/bar"
+#   label: "httpbin's /basic-auth"
+#   # the following promise rejection is expected
+#   error: "HTTP response code from <https://httpbin.org/basic-auth/foo/bar> is 401"
 
 - url: "https://httpbin.org/basic-auth/foo/bar"
   label: "httpbin's /basic-auth (with --auth-user and --auth-pass)"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -19,7 +19,7 @@
     cssCount: 1
     cssSize: 320
     jsCount: 1
-    jsSize: 29734  # compressed
+    jsSize: 29734 # compressed
     domains: 1
     DOMqueries: 20
     DOMqueriesById: 6
@@ -33,38 +33,46 @@
 
   offenders:
     gzipRequests:
-      - {url: 'http://127.0.0.1:8888/dom-operations.html', bodySize: 2094, transferedSize: 946 }
-      - {url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', bodySize: 84245, transferedSize: 29734 }
+      - {
+          url: "http://127.0.0.1:8888/dom-operations.html",
+          bodySize: 2094,
+          transferedSize: 946,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js",
+          bodySize: 84245,
+          transferedSize: 29734,
+        }
     htmlCount:
-      - { url: 'http://127.0.0.1:8888/dom-operations.html', size: 946 }
+      - { url: "http://127.0.0.1:8888/dom-operations.html", size: 946 }
     cssCount:
-      - { url: 'http://127.0.0.1:8888/static/style.css', size: 320 }
+      - { url: "http://127.0.0.1:8888/static/style.css", size: 320 }
     jsCount:
-      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', size: 29734 }
+      - { url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js", size: 29734 }
 
     DOMqueriesById:
-      - { id: 'foo', node: '#document' }
-      - { id: 'delete', node: '#document' }
-      - { id: 'foo', node: '#document' }
-      - { id: 'list1', node: '#document' }
-      - { id: 'list2', node: '#document' }
-      - { id: 'foobar', node: '#document' }
+      - { id: "foo", node: "#document" }
+      - { id: "delete", node: "#document" }
+      - { id: "foo", node: "#document" }
+      - { id: "list1", node: "#document" }
+      - { id: "list2", node: "#document" }
+      - { id: "foobar", node: "#document" }
     DOMqueriesByClassName:
-      - { class: 'barr', node: 'body' }
+      - { class: "barr", node: "body" }
     DOMqueriesByTagName:
-      - { tag: '*', node: 'div' }
-      - { tag: 'body', node: '#document' }
-      - { tag: 'script', node: 'DocumentFragment > strong[0]' }
-      - { tag: 'script', node: 'DocumentFragment > strong[0]' }
-      - { tag: 'strong', node: '#document' }
-      - { tag: 'strong', node: '#document' }
-      - { tag: 'li', node: 'body > ul#list1' }
-      - { tag: 'li', node: 'body > ul#list2' }
-      - { tag: 'a', node: 'div' }
-      - { tag: 'a', node: 'div' }
+      - { tag: "*", node: "div" }
+      - { tag: "body", node: "#document" }
+      - { tag: "script", node: "DocumentFragment > strong[0]" }
+      - { tag: "script", node: "DocumentFragment > strong[0]" }
+      - { tag: "strong", node: "#document" }
+      - { tag: "strong", node: "#document" }
+      - { tag: "li", node: "body > ul#list1" }
+      - { tag: "li", node: "body > ul#list2" }
+      - { tag: "a", node: "div" }
+      - { tag: "a", node: "div" }
     DOMinserts:
-      - { append: 'html > div[2]', node: 'html' }
-      - { append: 'body > p#foo > strong[0]', node: 'body > p#foo' }
+      - { append: "html > div[2]", node: "html" }
+      - { append: "body > p#foo > strong[0]", node: "body > p#foo" }
     DOMqueriesDuplicated:
       - { query: 'id "#foo" (in #document)', count: 2 }
       - { query: 'tag name "strong" (in #document)', count: 2 }
@@ -77,14 +85,14 @@
     DOMmutationsAttributes: 4
   offenders:
     DOMmutationsInserts:
-      - { node: 'strong[0]', target: 'p#foo' }
+      - { node: "strong[0]", target: "p#foo" }
     DOMmutationsRemoves:
-      - { node: 'span#delete', target: 'body' }
+      - { node: "span#delete", target: "body" }
     DOMmutationsAttributes:
-      - { attribute: 'style', node: 'body' }
-      - { attribute: 'style', node: 'body' }
-      - { attribute: 'style', node: 'p#foo' }
-      - { attribute: 'style', node: 'p#foo' }
+      - { attribute: "style", node: "body" }
+      - { attribute: "style", node: "body" }
+      - { attribute: "style", node: "p#foo" }
+      - { attribute: "style", node: "p#foo" }
 
 # DOM complexity
 - url: "/dom-complexity.html"
@@ -104,11 +112,11 @@
     whiteSpacesSize: 33
   offenders:
     hiddenImages:
-      - 'http://127.0.0.1:8888/static/mdn.png'
-      - 'http://127.0.0.1:8888/static/blank.gif'
-      - 'http://127.0.0.1:8888/static/example.svg'
+      - "http://127.0.0.1:8888/static/mdn.png"
+      - "http://127.0.0.1:8888/static/blank.gif"
+      - "http://127.0.0.1:8888/static/example.svg"
     nodesWithInlineCSS:
-      - { css: 'color: blue', node: 'p#foo' }
+      - { css: "color: blue", node: "p#foo" }
 
 # document height
 - url: "/document-height.html"
@@ -121,8 +129,20 @@
     imagesWithoutDimensions: 3
   offenders:
     imagesScaledDown:
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', naturalWidth: 600, naturalHeight: 529, imgWidth: 300, imgHeight: 265 }
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', naturalWidth: 600, naturalHeight: 529, imgWidth: 50, imgHeight: 50 }
+      - {
+          url: "http://127.0.0.1:8888/static/mdn.png",
+          naturalWidth: 600,
+          naturalHeight: 529,
+          imgWidth: 300,
+          imgHeight: 265,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/mdn.png",
+          naturalWidth: 600,
+          naturalHeight: 529,
+          imgWidth: 50,
+          imgHeight: 50,
+        }
 # duplicated ID (issue #392)
 - url: "/dom-id.html"
   metrics:
@@ -144,16 +164,18 @@
   offenders:
     cssParsingErrors:
       - {
-          url: '[inline CSS]',
-          value: { message: "missing '{'", position: {
-            end: { column: 2, line: 3 },
-            start: { column: 2, line: 3 }
-          }}
+          url: "[inline CSS]",
+          value:
+            {
+              message: "missing '{'",
+              position:
+                { end: { column: 2, line: 3 }, start: { column: 2, line: 3 } },
+            },
         }
     cssInlineStyles:
-      - { node: 'head > style[1]' }
-      - { node: 'body > style[0]' }
-      - { node: 'body > style[1]' }
+      - { node: "head > style[1]" }
+      - { node: "body > style[0]" }
+      - { node: "body > style[1]" }
 
 # analyze-css fails to parse a file (#404)
 - url: "/broken-css.html"
@@ -186,40 +208,68 @@
     eventsScrollBound: 2
   offenders:
     gzipRequests:
-      - { url: 'http://127.0.0.1:8888/jquery.html', transferedSize: 761, bodySize: 1027 }
-      - { url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js', transferedSize: 29734, bodySize: 84245 }
+      - {
+          url: "http://127.0.0.1:8888/jquery.html",
+          transferedSize: 761,
+          bodySize: 1027,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js",
+          transferedSize: 29734,
+          bodySize: 84245,
+        }
     eventsDispatched:
-      - { eventType: 'click', path: 'body > div#foo > span.bar' }
+      - { eventType: "click", path: "body > div#foo > span.bar" }
     eventsBound:
-      - { eventType: 'load', path: 'window' }
-      - { eventType: 'DOMContentLoaded', path: '#document' }
-      - { eventType: 'load', path: 'window' }
-      - { eventType: 'load', path: 'window' }
-      - { eventType: 'click', path: 'body > div#foo > span.bar' }
-      - { eventType: 'load', path: 'body > div#foo > span.bar' }
-      - { eventType: 'scroll', path: '#document' }
-      - { eventType: 'scroll', path: 'window' }
+      - { eventType: "load", path: "window" }
+      - { eventType: "DOMContentLoaded", path: "#document" }
+      - { eventType: "load", path: "window" }
+      - { eventType: "load", path: "window" }
+      - { eventType: "click", path: "body > div#foo > span.bar" }
+      - { eventType: "load", path: "body > div#foo > span.bar" }
+      - { eventType: "scroll", path: "#document" }
+      - { eventType: "scroll", path: "window" }
     eventsScrollBound:
-      - { element: '#document' }
-      - { element: 'window' }
+      - { element: "#document" }
+      - { element: "window" }
     jQueryVersionsLoaded:
       - version: "2.1.1"
-        url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js' 
+        url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js"
     jQueryWindowOnLoadFunctions:
       - http://127.0.0.1:8888/jquery.html:49:13
     jQueryEventTriggers:
-      - { type: 'click', element: 'body > div#foo > span.bar' }
-      - { element: '#document',  type: 'ready' }
-    jQuerySizzleCalls: 
-      - { selector: '#foo .bar', element: '#document' }
+      - { type: "click", element: "body > div#foo > span.bar" }
+      - { element: "#document", type: "ready" }
+    jQuerySizzleCalls:
+      - { selector: "#foo .bar", element: "#document" }
     jQueryDOMReads:
-      - { functionName: 'css', arguments: '["color"]', contextPath: 'body > div#foo > span.bar' }
+      - {
+          functionName: "css",
+          arguments: '["color"]',
+          contextPath: "body > div#foo > span.bar",
+        }
     jQueryDOMWrites:
-     - { functionName: 'css', arguments: '[{"color":"red","background":"green"}]', contextPath: 'body > div#foo > span.bar' }
-     - { functionName: 'css', arguments: '[{"background-color":"blue"}]', contextPath: 'body > div#foo' }
-     - { functionName: 'css', arguments: '[{"background-color":"blue"}]', contextPath: 'body > div#foo' }
+      - {
+          functionName: "css",
+          arguments: '[{"color":"red","background":"green"}]',
+          contextPath: "body > div#foo > span.bar",
+        }
+      - {
+          functionName: "css",
+          arguments: '[{"background-color":"blue"}]',
+          contextPath: "body > div#foo",
+        }
+      - {
+          functionName: "css",
+          arguments: '[{"background-color":"blue"}]',
+          contextPath: "body > div#foo",
+        }
     jQueryDOMWriteReadSwitches:
-      - { functionName: 'css', arguments: '["color"]', contextPath: 'body > div#foo > span.bar' }
+      - {
+          functionName: "css",
+          arguments: '["color"]',
+          contextPath: "body > div#foo > span.bar",
+        }
 
 # multiple jQuery "instances" (issue #435)
 - url: "/jquery-multiple.html"
@@ -233,12 +283,15 @@
     jQueryOnDOMReadyFunctions: 1
   offenders:
     jQueryVersionsLoaded:
-      - { version: "2.1.1", url: 'http://127.0.0.1:8888/static/jquery-2.1.1.min.js' }
-      - { version: "1.11.1", url: 'http://code.jquery.com/jquery-1.11.1.js' }
-    globalVariables: [ 'jQuery', '$' ]
+      - {
+          version: "2.1.1",
+          url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js",
+        }
+      - { version: "1.11.1", url: "http://code.jquery.com/jquery-1.11.1.js" }
+    globalVariables: ["jQuery", "$"]
     domains:
-      - { domain: '127.0.0.1', requests: 2 }
-      - { domain: 'code.jquery.com', requests: 1 }
+      - { domain: "127.0.0.1", requests: 2 }
+      - { domain: "code.jquery.com", requests: 1 }
 
 # --no-externals handling (issue #535)
 - url: "/jquery-multiple.html"
@@ -251,10 +304,10 @@
     blockedRequests: 1
     domains: 1
     jsErrors: 0
-    jQueryVersion: '2.1.1'
+    jQueryVersion: "2.1.1"
   offenders:
     blockedRequests:
-      - 'http://code.jquery.com/jquery-1.11.1.js'
+      - "http://code.jquery.com/jquery-1.11.1.js"
 # accept main domain in allow-domains
 - url: "/jquery-multiple.html"
   label: "/jquery-multiple.html (with --allow-domain)"
@@ -265,7 +318,7 @@
     requests: 3
     jsCount: 2
     blockedRequests: 0
-    jQueryVersion: '1.11.1'
+    jQueryVersion: "1.11.1"
 # jQuery read & write operations (issue #436)
 - url: "/jquery-reads-writes.html"
   metrics:
@@ -282,7 +335,10 @@
   offenders:
     assetsNotGzipped:
       # this JS response is not gzipped deliberately, refer to nginx-static.conf
-      - { url: 'http://127.0.0.1:8888/static/jquery-1.4.4.min.js', contentType: 'application/javascript' }
+      - {
+          url: "http://127.0.0.1:8888/static/jquery-1.4.4.min.js",
+          contentType: "application/javascript",
+        }
 
 # --wait-for-selector
 #- url: "/"
@@ -304,7 +360,7 @@
   label: "/wait-for-event.html (with --wait-for-event)"
   options:
     timeout: 4
-    'wait-for-event': "done"
+    "wait-for-event": "done"
   metrics:
     testFooBar: 123 # a metric set just before event trigger
   offenders:
@@ -316,7 +372,7 @@
   label: "/wait-for-event.html (with --post-load-delay)"
   options:
     timeout: 4
-    'post-load-delay': 1
+    "post-load-delay": 1
   metrics:
     testFooBar: 1 # first set value
 
@@ -324,7 +380,7 @@
   label: "/wait-for-event.html (with longer --post-load-delay)"
   options:
     timeout: 4
-    'post-load-delay': 3
+    "post-load-delay": 3
   metrics:
     testFooBar: 123 # a metric set just before event trigger
   offenders:
@@ -341,11 +397,11 @@
     domainsToDomComplete: 2
   offenders:
     domainsToDomContentLoaded:
-      - { domain: '127.0.0.1', requests: 2 }
-      - { domain: 'code.jquery.com', requests: 1 }
+      - { domain: "127.0.0.1", requests: 2 }
+      - { domain: "code.jquery.com", requests: 1 }
     domainsToDomComplete:
-      - { domain: '127.0.0.1', requests: 2 }
-      - { domain: 'code.jquery.com', requests: 1 }
+      - { domain: "127.0.0.1", requests: 2 }
+      - { domain: "code.jquery.com", requests: 1 }
   options:
     "wait-for-network-idle": true
 
@@ -359,10 +415,19 @@
     evalCalls: 2 # via eval() and setTimeout()
   offenders:
     documentWriteCalls:
-      - { message: 'document.write() used', caller: 'http://127.0.0.1:8888/bottlenecks.html:11:11' }
+      - {
+          message: "document.write() used",
+          caller: "http://127.0.0.1:8888/bottlenecks.html:11:11",
+        }
     evalCalls:
-      - { message: 'eval() called directly', caller: 'http://127.0.0.1:8888/bottlenecks.html:8:2' }
-      - { message: 'eval() called via setTimeout("foo()")', caller: 'http://127.0.0.1:8888/bottlenecks.html:9:2' }
+      - {
+          message: "eval() called directly",
+          caller: "http://127.0.0.1:8888/bottlenecks.html:8:2",
+        }
+      - {
+          message: 'eval() called via setTimeout("foo()")',
+          caller: "http://127.0.0.1:8888/bottlenecks.html:9:2",
+        }
 
 - url: "/bottlenecks.html"
   metrics:
@@ -370,9 +435,15 @@
     evalCalls: 1 # via setTimeout() only
   offenders:
     documentWriteCalls:
-      - { message: 'document.write() used', caller: 'http://127.0.0.1:8888/bottlenecks.html:11:11' }
+      - {
+          message: "document.write() used",
+          caller: "http://127.0.0.1:8888/bottlenecks.html:11:11",
+        }
     evalCalls:
-      - { message: 'eval() called via setTimeout("foo()")', caller: 'http://127.0.0.1:8888/bottlenecks.html:9:2' }
+      - {
+          message: 'eval() called via setTimeout("foo()")',
+          caller: "http://127.0.0.1:8888/bottlenecks.html:9:2",
+        }
 
 # stop-at-onload (#513)
 - url: "/after-onload.html"
@@ -383,7 +454,7 @@
     requests: 2
   offenders:
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
+      - { url: "http://127.0.0.1:8888/static/blank.gif", size: 342 }
 
 - url: "/after-onload.html"
   label: "/after-onload.html (with --wait-for-network-idle)"
@@ -395,8 +466,8 @@
     requests: 3
   offenders:
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20690 }
+      - { url: "http://127.0.0.1:8888/static/blank.gif", size: 342 }
+      - { url: "http://127.0.0.1:8888/static/mdn.png", size: 20690 }
 
 # lazy-loadable-images.html (#494)
 - url: "/lazy-loadable-images.html"
@@ -404,10 +475,26 @@
     lazyLoadableImagesBelowTheFold: 4
   offenders:
     lazyLoadableImagesBelowTheFold:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', node: 'body > img#dot', offset: 900 }
-      - { url: 'http://127.0.0.1:8888/static/example.svg', node: 'body > footer[2] > img[2]', offset: 1578 }
-      - { url: 'http://127.0.0.1:8888/static/75x120.jpg', node: 'body > footer[2] > picture[4] > img[1]', offset: 1508 }
-      - { url: 'http://127.0.0.1:8888/static/150x100.jpg', node: 'body > footer[2] > img[5]', offset: 1528 }
+      - {
+          url: "http://127.0.0.1:8888/static/blank.gif",
+          node: "body > img#dot",
+          offset: 900,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/example.svg",
+          node: "body > footer[2] > img[2]",
+          offset: 1578,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/75x120.jpg",
+          node: "body > footer[2] > picture[4] > img[1]",
+          offset: 1508,
+        }
+      - {
+          url: "http://127.0.0.1:8888/static/150x100.jpg",
+          node: "body > footer[2] > img[5]",
+          offset: 1528,
+        }
 
 # JS globals (#482)
 - url: "/js-globals.html"
@@ -416,9 +503,9 @@
     globalVariablesFalsy: 1
     jsErrors: 0
   offenders:
-    globalVariables: [ 'a_global', 'falsy', 'foo' ]
+    globalVariables: ["a_global", "falsy", "foo"]
     globalVariablesFalsy:
-      - { name: 'falsy', value: false }
+      - { name: "falsy", value: false }
 # JS redirects (#550)
 - url: "/js-redirect.html"
   metrics:
@@ -435,11 +522,11 @@
     postRequests: 1
   offenders:
     ajaxRequests:
-      - { url: '/static/style.css', method: 'POST' }
-      - { url: '/static/broken.css', method: 'GET' }
-      - { url: '/static/foo', method: 'GET' }
+      - { url: "/static/style.css", method: "POST" }
+      - { url: "/static/broken.css", method: "GET" }
+      - { url: "/static/foo", method: "GET" }
     postRequests:
-      - 'http://127.0.0.1:8888/static/style.css'
+      - "http://127.0.0.1:8888/static/style.css"
   options:
     "wait-for-network-idle": true
 
@@ -450,10 +537,10 @@
     synchronousXHR: 1
   offenders:
     ajaxRequests:
-      - { url: 'jquery.html', method: 'GET' }
-      - { url: 'inline-css.html', method: 'GET' }
+      - { url: "jquery.html", method: "GET" }
+      - { url: "inline-css.html", method: "GET" }
     synchronousXHR:
-      - { url: 'inline-css.html', method: 'GET' }
+      - { url: "inline-css.html", method: "GET" }
 
 # multiple cookies (#597)
 - url: "/cookies.html"
@@ -471,7 +558,7 @@
   metrics:
     localStorageEntries: 2
   offenders:
-    localStorageEntries: ['foo', 'test']
+    localStorageEntries: ["foo", "test"]
 # JS errors
 - url: "/js-errors.html"
   metrics:
@@ -484,7 +571,7 @@
   offenders:
     consoleMessages:
       - 'log:["Hi!"]'
-      - 'Bye, %d! 42'
+      - "Bye, %d! 42"
 
 # headers
 - url: "/headers.html"
@@ -506,33 +593,40 @@
     cachingTooShort: 1
   offenders:
     cachingTooShort:
-     - { url: 'http://127.0.0.1:8888/static/mdn.png', ttl: 86400 }
+      - { url: "http://127.0.0.1:8888/static/mdn.png", ttl: 86400 }
 
 # requestsStats
 - url: "/headers.html"
   metrics:
     requests: 2
-    bodySize: 1065  # uncompressed content of all responses (without headers)
+    bodySize: 1065 # uncompressed content of all responses (without headers)
     contentLength: 1198 # transfered bytes
-    smallestResponse: 342  # headers + body size
+    smallestResponse: 342 # headers + body size
     biggestResponse: 856
   offenders:
     requests:
-      - { url: 'http://127.0.0.1:8888/headers.html', type: 'html', size: 856 }
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', type: 'image', size: 342 }
+      - { url: "http://127.0.0.1:8888/headers.html", type: "html", size: 856 }
+      - {
+          url: "http://127.0.0.1:8888/static/blank.gif",
+          type: "image",
+          size: 342,
+        }
     smallestResponse:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
+      - { url: "http://127.0.0.1:8888/static/blank.gif", size: 342 }
     biggestResponse:
-      - { url: 'http://127.0.0.1:8888/headers.html', size: 856 }
+      - { url: "http://127.0.0.1:8888/headers.html", size: 856 }
 
 # iframes
 - url: "/iframe.html"
   metrics:
-    requests: 5  # include requests for iframe and its content
+    requests: 5 # include requests for iframe and its content
     iframesCount: 1
   offenders:
     iframesCount:
-     - { element: 'body > iframe[1]', url: 'http://127.0.0.1:8888/image-scaling.html' }
+      - {
+          element: "body > iframe[1]",
+          url: "http://127.0.0.1:8888/image-scaling.html",
+        }
 
 # not found
 - url: "/not-found.html"
@@ -541,11 +635,14 @@
     notFound: 1
   offenders:
     requests:
-      - { url: 'http://127.0.0.1:8888/not-found.html', type: 'html', size: 380 }
-      - { url: 'http://127.0.0.1:8888/not_found/foo.js', type: 'html', size: 177 }
+      - { url: "http://127.0.0.1:8888/not-found.html", type: "html", size: 380 }
+      - {
+          url: "http://127.0.0.1:8888/not_found/foo.js",
+          type: "html",
+          size: 177,
+        }
     notFound:
-      - 'http://127.0.0.1:8888/not_found/foo.js'
-
+      - "http://127.0.0.1:8888/not_found/foo.js"
 
 # alerts, prompts, confirms
 - url: "/alerts-prompts.html"
@@ -554,15 +651,15 @@
     windowConfirms: 1
     windowPrompts: 1
   offenders:
-    windowAlerts: [ 'Oh dear!' ]
-    windowConfirms: [ 'Oh dear?' ]
-    windowPrompts: [ "What's your name, dear?" ]
+    windowAlerts: ["Oh dear!"]
+    windowConfirms: ["Oh dear?"]
+    windowPrompts: ["What's your name, dear?"]
 
 # JSON
 - url: "/ajax-json.html"
   label: "/ajax-json.html (waiting for 'body.loaded')"
   options:
-    "wait-for-selector": 'body.loaded'
+    "wait-for-selector": "body.loaded"
   metrics:
     ajaxRequests: 1
     consoleMessages: 2
@@ -570,14 +667,14 @@
     jsonSize: 345
   offenders:
     ajaxRequests:
-      - { url: '/foo.json', method: 'GET' }
+      - { url: "/foo.json", method: "GET" }
     jsonCount:
-      - { url: 'http://127.0.0.1:8888/foo.json', size: 345 }
+      - { url: "http://127.0.0.1:8888/foo.json", size: 345 }
     consoleMessages:
       - 'log:["Ajax fetched"]'
       - 'log:["Page fully loaded"]'
     DOMmutationsAttributes:
-      - { attribute: 'class', node: 'body' } # we add "loaded" class to <body>
+      - { attribute: "class", node: "body" } # we add "loaded" class to <body>
 
 # scroll
 - url: "/lazy-load-scroll.html"
@@ -594,7 +691,7 @@
     imageCount: 1
   offenders:
     imageCount:
-      - { url: 'http://127.0.0.1:8888/static/mdn.png', size: 20690 }
+      - { url: "http://127.0.0.1:8888/static/mdn.png", size: 20690 }
     consoleMessages:
       - 'log:["Lazy loading /static/mdn.png"]'
 
@@ -602,107 +699,110 @@
 - url: "/devices.html"
   label: "/devices.html"
   metrics:
-    viewport: '800x600' # a default
+    viewport: "800x600" # a default
 
 - url: "/devices.html"
   label: "/devices.html (with --phone)"
   options:
     phone: true
   metrics:
-    userAgent: 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36'
-    viewport: '360x640'
+    userAgent: "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36"
+    viewport: "360x640"
 
 - url: "/devices.html"
   label: "/devices.html (with --phone-landscape)"
   options:
     "phone-landscape": true
   metrics:
-    userAgent: 'Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36'
-    viewport: '640x360'
+    userAgent: "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36"
+    viewport: "640x360"
 
 - url: "/devices.html"
   label: "/devices.html (with --tablet)"
   options:
     tablet: true
   metrics:
-    userAgent: 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true'
-    viewport: '800x1280'
+    userAgent: "Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true"
+    viewport: "800x1280"
 
 - url: "/devices.html"
   label: "/devices.html (with --tablet-landscape)"
   options:
     "tablet-landscape": true
   metrics:
-    userAgent: 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true'
-    viewport: '1280x800'
+    userAgent: "Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true"
+    viewport: "1280x800"
 
 # viewport
 - url: "/viewport.html"
   label: "/viewport.html (with --viewport 1100x700)"
   options:
-    viewport: '1100x700'
+    viewport: "1100x700"
   metrics:
-    viewport: '1100x700'
+    viewport: "1100x700"
     devicePixelRatio: 1
 
 # viewport
 - url: "/viewport.html"
   label: "/viewport.html (with --viewport 1100x700x2)"
   options:
-    viewport: '1100x700x2'
+    viewport: "1100x700x2"
   metrics:
-    viewport: '1100x700'
+    viewport: "1100x700"
     devicePixelRatio: 2
 
 # viewport
 - url: "/viewport.html"
   label: "/viewport.html (with --viewport 1100x700x2.5)"
   options:
-    viewport: '1100x700x2.5'
+    viewport: "1100x700x2.5"
   metrics:
-    viewport: '1100x700'
+    viewport: "1100x700"
     devicePixelRatio: 2.5
 
 # https and webfonts
 - url: "/https-fonts.html"
   options:
-    "wait-for-network-idle": true  # wait for webfont file
+    "wait-for-network-idle": true # wait for webfont file
   metrics:
     requests: 3
     httpsRequests: 2
     webfontCount: 1
   offenders:
     domains:
-      - { domain: '127.0.0.1', requests: 1 }
-      - { domain: 'fonts.googleapis.com', requests: 1 }
-      - { domain: 'fonts.gstatic.com', requests: 1 }
+      - { domain: "127.0.0.1", requests: 1 }
+      - { domain: "fonts.googleapis.com", requests: 1 }
+      - { domain: "fonts.gstatic.com", requests: 1 }
 
 # staticAssets
 - url: "/assets.html"
   offenders:
     assetsWithQueryString:
-      - { url: 'http://127.0.0.1:8888/static/mdn.png?cb=123', contentType: 'image/png' }
+      - {
+          url: "http://127.0.0.1:8888/static/mdn.png?cb=123",
+          contentType: "image/png",
+        }
     smallImages:
-      - { url: 'http://127.0.0.1:8888/static/blank.gif', size: 342 }
+      - { url: "http://127.0.0.1:8888/static/blank.gif", size: 342 }
     smallCssFiles:
-      - { url: 'http://127.0.0.1:8888/static/style.css', size: 320 }
+      - { url: "http://127.0.0.1:8888/static/style.css", size: 320 }
 
 # authentication
 - url: "https://httpbin.org/basic-auth/foo/bar"
   label: "httpbin's /basic-auth"
   # the following promise rejection is expected
-  error: 'HTTP response code from <https://httpbin.org/basic-auth/foo/bar> is 401'
+  error: "HTTP response code from <https://httpbin.org/basic-auth/foo/bar> is 401"
 
 - url: "https://httpbin.org/basic-auth/foo/bar"
   label: "httpbin's /basic-auth (with --auth-user and --auth-pass)"
   options:
-    auth-user: 'foo'
-    auth-pass: 'bar'
+    auth-user: "foo"
+    auth-pass: "bar"
   metrics:
     requests: 1
   offenders:
     httpsRequests:
-      - 'https://httpbin.org/basic-auth/foo/bar'
+      - "https://httpbin.org/basic-auth/foo/bar"
 
 #
 # integration-test-extra section
@@ -714,7 +814,7 @@
 - url: "/page-source.html"
   options:
     "page-source": true
-  assertFunction: pageSource  # run pageSource() from integration-test-extra.js
+  assertFunction: pageSource # run pageSource() from integration-test-extra.js
 
 # screenshot
 - url: "/image-scaling.html"

--- a/test/integration-test-extra.js
+++ b/test/integration-test-extra.js
@@ -1,39 +1,39 @@
-const assert = require('assert'),
-    fs = require('fs');
+const assert = require("assert"),
+  fs = require("fs");
 
 function pageSource(phantomas, batch) {
-    var path;
+  var path;
 
-    phantomas.on('pageSource', _path => {
-        path = _path;
-    });
+  phantomas.on("pageSource", (_path) => {
+    path = _path;
+  });
 
-    batch['HTML file with page should be saved'] = () => {
-        assert.ok(typeof path === 'string', 'pageSource event should get a path');
+  batch["HTML file with page should be saved"] = () => {
+    assert.ok(typeof path === "string", "pageSource event should get a path");
 
-        // https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options
-        const content = fs.readFileSync(path, {encoding: 'utf-8'});
-        // console.log(content);
+    // https://nodejs.org/api/fs.html#fs_fs_readfilesync_path_options
+    const content = fs.readFileSync(path, { encoding: "utf-8" });
+    // console.log(content);
 
-        assert.ok(content.indexOf('<h1 id="foo">bar</h1>') > -1);
-    };
+    assert.ok(content.indexOf('<h1 id="foo">bar</h1>') > -1);
+  };
 }
 
 function screenshot(phantomas, batch) {
-    var path;
+  var path;
 
-    phantomas.on('screenshot', _path => {
-        path = _path;
-    });
+  phantomas.on("screenshot", (_path) => {
+    path = _path;
+  });
 
-    batch['PNG file should be saved'] = () => {
-        assert.ok(typeof path === 'string', 'screenshot event should get a path');
-        assert.ok(fs.existsSync(path), 'The file should exist');
-        assert.ok(path.match(/.png$/), 'The file should be a PNG');
-    };
+  batch["PNG file should be saved"] = () => {
+    assert.ok(typeof path === "string", "screenshot event should get a path");
+    assert.ok(fs.existsSync(path), "The file should exist");
+    assert.ok(path.match(/.png$/), "The file should be a PNG");
+  };
 }
 
 module.exports = {
-    pageSource,
-    screenshot
+  pageSource,
+  screenshot,
 };

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -12,6 +12,13 @@ var vows = require('vows'),
 
 var WEBROOT = 'http://127.0.0.1:8888'; // see start-server.sh
 
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+	throw err;
+});
+
 // run the test
 var suite = vows.describe('Integration tests').addBatch({
 	'test server': {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -33,12 +33,12 @@ var suite = vows.describe("Integration tests").addBatch({
         .on("error", self.callback);
     },
     "should be up and running": function (err, res) {
-      assert.equal(
+      assert.strictEqual(
         typeof res !== "undefined",
         true,
         "responses to the request"
       );
-      assert.equal(res.statusCode, 200, "responses with HTTP 200");
+      assert.strictEqual(res.statusCode, 200, "responses with HTTP 200");
     },
   },
 });

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1,98 +1,116 @@
 /**
  * Integration tests using server-start.sh script
  */
-'use strict';
+"use strict";
 
-var vows = require('vows'),
-	assert = require('assert'),
-	fs = require('fs'),
-	yaml = require('js-yaml'),
-	phantomas = require('..'),
-	extras = require('./integration-test-extra');
+var vows = require("vows"),
+  assert = require("assert"),
+  fs = require("fs"),
+  yaml = require("js-yaml"),
+  phantomas = require(".."),
+  extras = require("./integration-test-extra");
 
-var WEBROOT = 'http://127.0.0.1:8888'; // see start-server.sh
+var WEBROOT = "http://127.0.0.1:8888"; // see start-server.sh
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-	throw err;
+process.on("unhandledRejection", (err) => {
+  throw err;
 });
 
 // run the test
-var suite = vows.describe('Integration tests').addBatch({
-	'test server': {
-		topic: function() {
-			var http = require('http'),
-				self = this;
+var suite = vows.describe("Integration tests").addBatch({
+  "test server": {
+    topic: function () {
+      var http = require("http"),
+        self = this;
 
-			http.get(WEBROOT + '/', function(res) {
-				self.callback(null, res);
-			}).on('error', self.callback);
-		},
-		'should be up and running': function(err, res) {
-			assert.equal(typeof res !== 'undefined', true, 'responses to the request');
-			assert.equal(res.statusCode, 200, 'responses with HTTP 200');
-		}
-	}
+      http
+        .get(WEBROOT + "/", function (res) {
+          self.callback(null, res);
+        })
+        .on("error", self.callback);
+    },
+    "should be up and running": function (err, res) {
+      assert.equal(
+        typeof res !== "undefined",
+        true,
+        "responses to the request"
+      );
+      assert.equal(res.statusCode, 200, "responses with HTTP 200");
+    },
+  },
 });
 
 // register tests from spec file
-var raw = fs.readFileSync(__dirname + '/integration-spec.yaml').toString(),
-	spec = yaml.safeLoad(raw);
+var raw = fs.readFileSync(__dirname + "/integration-spec.yaml").toString(),
+  spec = yaml.safeLoad(raw);
 
-spec.forEach(function(test) {
-	var batch = {},
-		batchName = test.label || test.url;
+spec.forEach(function (test) {
+  var batch = {},
+    batchName = test.label || test.url;
 
-	batch[batchName] = {
-		topic: function() {
-			const url = test.url[0] == '/' ? WEBROOT + test.url : test.url,
-				promise = phantomas(url, test.options || {});
+  batch[batchName] = {
+    topic: function () {
+      const url = test.url[0] == "/" ? WEBROOT + test.url : test.url,
+        promise = phantomas(url, test.options || {});
 
-			promise.
-				then(res => this.callback(null, res)).
-				catch(err => this.callback(null, err))
+      promise
+        .then((res) => this.callback(null, res))
+        .catch((err) => this.callback(null, err));
 
-			if (test.assertFunction) {
-				extras[test.assertFunction](promise, batch[batchName]);
-			}
-		},
-		'should be generated': (err, res) => {
-			assert.ok(!(res instanceof Error), 'No error should be thrown: got ' + res);
-			assert.ok(res.getMetric instanceof Function, 'Results wrapper should be passed');
-		},
-	};
+      if (test.assertFunction) {
+        extras[test.assertFunction](promise, batch[batchName]);
+      }
+    },
+    "should be generated": (err, res) => {
+      assert.ok(
+        !(res instanceof Error),
+        "No error should be thrown: got " + res
+      );
+      assert.ok(
+        res.getMetric instanceof Function,
+        "Results wrapper should be passed"
+      );
+    },
+  };
 
-	// check for errors
-	if (test.error) {
-		delete batch[batchName]['should be generated'];
+  // check for errors
+  if (test.error) {
+    delete batch[batchName]["should be generated"];
 
-		batch[batchName]['should reject a promise'] = (_, err) => {
-			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
-			assert.ok(err instanceof Error);
-			assert.ok(err.message.indexOf(test.error) === 0, test.error + ' should be raised');
-		};
-	}
+    batch[batchName]["should reject a promise"] = (_, err) => {
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+      assert.ok(err instanceof Error);
+      assert.ok(
+        err.message.indexOf(test.error) === 0,
+        test.error + " should be raised"
+      );
+    };
+  }
 
-	// check metrics
-	Object.keys(test.metrics || {}).forEach(function(name) {
-		batch[batchName]['should have "' + name + '" metric properly set'] = function(err, results) {
-			assert.ok(!(err instanceof Error), 'Error should not be thrown: ' + err);
-			assert.strictEqual(results.getMetric(name), test.metrics[name]);
-		};
-	});
+  // check metrics
+  Object.keys(test.metrics || {}).forEach(function (name) {
+    batch[batchName][
+      'should have "' + name + '" metric properly set'
+    ] = function (err, results) {
+      assert.ok(!(err instanceof Error), "Error should not be thrown: " + err);
+      assert.strictEqual(results.getMetric(name), test.metrics[name]);
+    };
+  });
 
-	// check offenders
-	Object.keys(test.offenders || {}).forEach(function(name) {
-		batch[batchName]['should have "' + name + '" offender(s) properly set'] = function(err, results) {
-			assert.ok(!(err instanceof Error), 'Error should not be thrown: ' + err);
-			assert.deepStrictEqual(results.getOffenders(name), test.offenders[name]);
-		};
-	});
+  // check offenders
+  Object.keys(test.offenders || {}).forEach(function (name) {
+    batch[batchName][
+      'should have "' + name + '" offender(s) properly set'
+    ] = function (err, results) {
+      assert.ok(!(err instanceof Error), "Error should not be thrown: " + err);
+      assert.deepStrictEqual(results.getOffenders(name), test.offenders[name]);
+    };
+  });
 
-
-	suite.addBatch(batch);
+  suite.addBatch(batch);
 });
 
 suite.export(module);

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -1,30 +1,32 @@
 /**
  * Tests CommonJS module
  */
-'use strict';
+"use strict";
 
-var vows = require('vows'),
-	assert = require('assert'),
-	phantomas = require('..');
+var vows = require("vows"),
+  assert = require("assert"),
+  phantomas = require("..");
 
-const URL = 'http://127.0.0.1:8888/';
+const URL = "http://127.0.0.1:8888/";
 
 // run the test
-vows.describe('CommonJS module\'s promise').addBatch({
-	'when not provided with URL': {
-		topic: function() {
-			const promise = phantomas(false);
+vows
+  .describe("CommonJS module's promise")
+  .addBatch({
+    "when not provided with URL": {
+      topic: function () {
+        const promise = phantomas(false);
 
-			promise.
-				then(res => this.callback(null, res)).
-				catch(err => this.callback(null, err));
-		},
-		'should reject a promise': (_, err) => {
-			assert.ok(err instanceof Error);
-			assert.strictEqual(err.message, 'URL must be a string');
-		}
-	},
-	/**'when timed out': {
+        promise
+          .then((res) => this.callback(null, res))
+          .catch((err) => this.callback(null, err));
+      },
+      "should reject a promise": (_, err) => {
+        assert.ok(err instanceof Error);
+        assert.strictEqual(err.message, "URL must be a string");
+      },
+    },
+    /**'when timed out': {
 		topic: function() {
 			const promise = phantomas('http://phantomjs.org/', {
 				timeout: 1 // [ms]
@@ -39,20 +41,21 @@ vows.describe('CommonJS module\'s promise').addBatch({
 			assert.strictEqual(err.message, 'Navigation Timeout Exceeded: 10ms exceeded');
 		}
 	}, */
-	'a valid URL': {
-		topic: function() {
-			const promise = phantomas(URL);
+    "a valid URL": {
+      topic: function () {
+        const promise = phantomas(URL);
 
-			promise.
-				then(res => this.callback(null, res)).
-				catch(err => this.callback(null, err));
-		},
-		'should not reject a promise': (_, err) => {
-			assert.ok(!(err instanceof Error), err.message);
-		},
-		'should be resolved': function(_, res) {
-			assert.equal(typeof res.getMetrics, 'function');
-			assert.equal(typeof res.setMetric, 'function');
-		}
-	}
-}).export(module);
+        promise
+          .then((res) => this.callback(null, res))
+          .catch((err) => this.callback(null, err));
+      },
+      "should not reject a promise": (_, err) => {
+        assert.ok(!(err instanceof Error), err.message);
+      },
+      "should be resolved": function (_, res) {
+        assert.equal(typeof res.getMetrics, "function");
+        assert.equal(typeof res.setMetric, "function");
+      },
+    },
+  })
+  .export(module);

--- a/test/modules/cacheHits-test.js
+++ b/test/modules/cacheHits-test.js
@@ -1,97 +1,146 @@
 /**
  * Test cacheHits module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('cacheHits').
-addBatch({
-	'no caching headers': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {}
-		}).report();
-	}, {
-		'cacheHits': 0,
-		'cacheMisses': 0,
-		'cachePasses': 0
-	}),
-	'Age header (hit)': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'Age': '14365'
-			}
-		}).report();
-	}, {
-		'cacheHits': 1,
-		'cacheMisses': 0,
-		'cachePasses': 0
-	}),
-	'Age + X-Cache header (hit)': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'Age': '14365',
-				'X-Cache': 'HIT'
-			}
-		}).report();
-	}, {
-		'cacheHits': 1,
-		'cacheMisses': 0,
-		'cachePasses': 0
-	}),
-	'Age header (0 seconds)': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'Age': '0'
-			}
-		}).report();
-	}, {
-		'cacheHits': 0,
-		'cacheMisses': 1,
-		'cachePasses': 0
-	}),
-	'hits': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'X-Cache': 'HIT'
-			}
-		}).report();
-	}, {
-		'cacheHits': 1,
-		'cacheMisses': 0,
-		'cachePasses': 0
-	}),
-	'hits (following the miss)': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'X-Cache': 'HIT, MISS'
-			}
-		}).report();
-	}, {
-		'cacheHits': 1,
-		'cacheMisses': 0,
-		'cachePasses': 0
-	}),
-	'misses': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'X-Cache': 'MISS'
-			}
-		}).report();
-	}, {
-		'cacheHits': 0,
-		'cacheMisses': 1,
-		'cachePasses': 0
-	}),
-	'passes': mock.getContext('cacheHits', function(phantomas) {
-		return phantomas.recv({
-			headers: {
-				'X-Cache': 'PASS'
-			}
-		}).report();
-	}, {
-		'cacheHits': 0,
-		'cacheMisses': 0,
-		'cachePasses': 1
-	}),
-}).
-export(module);
+vows
+  .describe("cacheHits")
+  .addBatch({
+    "no caching headers": mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {},
+          })
+          .report();
+      },
+      {
+        cacheHits: 0,
+        cacheMisses: 0,
+        cachePasses: 0,
+      }
+    ),
+    "Age header (hit)": mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              Age: "14365",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 1,
+        cacheMisses: 0,
+        cachePasses: 0,
+      }
+    ),
+    "Age + X-Cache header (hit)": mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              Age: "14365",
+              "X-Cache": "HIT",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 1,
+        cacheMisses: 0,
+        cachePasses: 0,
+      }
+    ),
+    "Age header (0 seconds)": mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              Age: "0",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 0,
+        cacheMisses: 1,
+        cachePasses: 0,
+      }
+    ),
+    hits: mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              "X-Cache": "HIT",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 1,
+        cacheMisses: 0,
+        cachePasses: 0,
+      }
+    ),
+    "hits (following the miss)": mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              "X-Cache": "HIT, MISS",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 1,
+        cacheMisses: 0,
+        cachePasses: 0,
+      }
+    ),
+    misses: mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              "X-Cache": "MISS",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 0,
+        cacheMisses: 1,
+        cachePasses: 0,
+      }
+    ),
+    passes: mock.getContext(
+      "cacheHits",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            headers: {
+              "X-Cache": "PASS",
+            },
+          })
+          .report();
+      },
+      {
+        cacheHits: 0,
+        cacheMisses: 0,
+        cachePasses: 1,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/caching-test.js
+++ b/test/modules/caching-test.js
@@ -1,94 +1,142 @@
 /**
  * Test caching module
  */
-const vows = require('vows'),
-	mock = require('./mock'),
-	URL = 'http://127.0.0.1:8888/static/mdn.png';
+const vows = require("vows"),
+  mock = require("./mock"),
+  URL = "http://127.0.0.1:8888/static/mdn.png";
 
-vows.describe('caching').
-addBatch({
-	'caching not specified': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'X-Foo': 'Bar'
-			}
-		}).report();
-	}, {
-		'cachingNotSpecified': 1
-	}, {
-		'cachingNotSpecified': [URL]
-	}),
-	'old caching header used (Expires)': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'Expires': 'Wed, 21 Oct 2015 07:28:00 GMT'
-			}
-		}).report();
-	}, {
-		'oldCachingHeaders': 1,
-		'cachingNotSpecified': 0,
-		'cachingDisabled': 1,
-	}, {
-		'cachingDisabled': [URL]
-	}),
-	'old caching header used (Pragma)': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'Pragma': 'no-cache'
-			}
-		}).report();
-	}, {
-		'oldCachingHeaders': 1,
-		'cachingNotSpecified': 1
-	}, {
-		'oldCachingHeaders': [{headerName: 'Pragma', url: 'http://127.0.0.1:8888/static/mdn.png', value: 'no-cache'}],
-		'cachingNotSpecified': [URL]
-	}),
-	'caching too short': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'Cache-Control': 'max-age=600'
-			}
-		}).report();
-	}, {
-		'cachingTooShort': 1,
-		'cachingUseImmutable': 0,
-	}, {
-		'cachingTooShort': [{url: URL, ttl: 600}],
-	}),
-	'caching not too short (but without immutable)': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'Cache-Control': 'max-age=2592000' // 30 days
-			}
-		}).report();
-	}, {
-		'cachingTooShort': 0,
-		'cachingUseImmutable': 1,
-	}, {
-		'cachingUseImmutable': [{ url: URL, ttl: 2592000 }]
-	}),
-	'caching not too short (and use immutable)': mock.getContext('caching', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			isImage: true,
-			headers: {
-				'Cache-Control': 'max-age=2592000, immutable' // 30 days
-			}
-		}).report();
-	}, {
-		'cachingTooShort': 0,
-		'cachingUseImmutable': 0,
-	}),
-}).
-export(module);
+vows
+  .describe("caching")
+  .addBatch({
+    "caching not specified": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              "X-Foo": "Bar",
+            },
+          })
+          .report();
+      },
+      {
+        cachingNotSpecified: 1,
+      },
+      {
+        cachingNotSpecified: [URL],
+      }
+    ),
+    "old caching header used (Expires)": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              Expires: "Wed, 21 Oct 2015 07:28:00 GMT",
+            },
+          })
+          .report();
+      },
+      {
+        oldCachingHeaders: 1,
+        cachingNotSpecified: 0,
+        cachingDisabled: 1,
+      },
+      {
+        cachingDisabled: [URL],
+      }
+    ),
+    "old caching header used (Pragma)": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              Pragma: "no-cache",
+            },
+          })
+          .report();
+      },
+      {
+        oldCachingHeaders: 1,
+        cachingNotSpecified: 1,
+      },
+      {
+        oldCachingHeaders: [
+          {
+            headerName: "Pragma",
+            url: "http://127.0.0.1:8888/static/mdn.png",
+            value: "no-cache",
+          },
+        ],
+        cachingNotSpecified: [URL],
+      }
+    ),
+    "caching too short": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              "Cache-Control": "max-age=600",
+            },
+          })
+          .report();
+      },
+      {
+        cachingTooShort: 1,
+        cachingUseImmutable: 0,
+      },
+      {
+        cachingTooShort: [{ url: URL, ttl: 600 }],
+      }
+    ),
+    "caching not too short (but without immutable)": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              "Cache-Control": "max-age=2592000", // 30 days
+            },
+          })
+          .report();
+      },
+      {
+        cachingTooShort: 0,
+        cachingUseImmutable: 1,
+      },
+      {
+        cachingUseImmutable: [{ url: URL, ttl: 2592000 }],
+      }
+    ),
+    "caching not too short (and use immutable)": mock.getContext(
+      "caching",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            url: URL,
+            isImage: true,
+            headers: {
+              "Cache-Control": "max-age=2592000, immutable", // 30 days
+            },
+          })
+          .report();
+      },
+      {
+        cachingTooShort: 0,
+        cachingUseImmutable: 0,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/domains-test.js
+++ b/test/modules/domains-test.js
@@ -1,38 +1,45 @@
 /**
  * Test domains module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('domains').addBatch({
-	'module': mock.getContext('domains', function(phantomas) {
-		var domains = [];
+vows
+  .describe("domains")
+  .addBatch({
+    module: mock.getContext(
+      "domains",
+      function (phantomas) {
+        var domains = [];
 
-		domains.push({
-			name: 'example.com',
-			cnt: 2
-		});
-		domains.push({
-			name: 'awesome.cdn.com',
-			cnt: 6
-		});
-		domains.push({
-			name: 'ads.co.uk',
-			cnt: 3
-		});
+        domains.push({
+          name: "example.com",
+          cnt: 2,
+        });
+        domains.push({
+          name: "awesome.cdn.com",
+          cnt: 6,
+        });
+        domains.push({
+          name: "ads.co.uk",
+          cnt: 3,
+        });
 
-		domains.forEach(function(domain) {
-			for (var i = 0; i < domain.cnt; i++) {
-				phantomas.recv({
-					domain: domain.name
-				});
-			}
-		});
+        domains.forEach(function (domain) {
+          for (var i = 0; i < domain.cnt; i++) {
+            phantomas.recv({
+              domain: domain.name,
+            });
+          }
+        });
 
-		// calculate metrics
-		return phantomas.report();
-	}, {
-		'domains': 3,
-		'maxRequestsPerDomain': 6
-	})
-}).export(module);
+        // calculate metrics
+        return phantomas.report();
+      },
+      {
+        domains: 3,
+        maxRequestsPerDomain: 6,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/keepAlive-test.js
+++ b/test/modules/keepAlive-test.js
@@ -1,53 +1,75 @@
 /**
  * Test cacheHits module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('keepAlive').
-addBatch({
-	'connection closed, no more requests': mock.getContext('keepAlive', function(phantomas) {
-		return phantomas.recv({
-			protocol: 'http',
-			domain: 'foo.net',
-			url: 'http://foo.net/',
-			headers: {
-				'Connection': 'close'
-			}
-		}).send({
-			protocol: 'http',
-			domain: 'foo.bar'
-		}).report();
-	}, {
-		'closedConnections': 0
-	}),
-	'connection closed, more requests': mock.getContext('keepAlive', function(phantomas) {
-		return phantomas.recv({
-			protocol: 'http',
-			domain: 'foo.net',
-			url: 'http://foo.net/',
-			headers: {
-				'Connection': 'close'
-			}
-		}).send({
-			protocol: 'http',
-			domain: 'foo.net'
-		}).report();
-	}, {
-		'closedConnections': 1
-	}),
-	'connection not closed, more requests': mock.getContext('keepAlive', function(phantomas) {
-		return phantomas.recv({
-			protocol: 'http',
-			domain: 'foo.net',
-			url: 'http://foo.net/',
-			headers: {}
-		}).send({
-			protocol: 'http',
-			domain: 'foo.net'
-		}).report();
-	}, {
-		'closedConnections': 0
-	}),
-}).
-export(module);
+vows
+  .describe("keepAlive")
+  .addBatch({
+    "connection closed, no more requests": mock.getContext(
+      "keepAlive",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            protocol: "http",
+            domain: "foo.net",
+            url: "http://foo.net/",
+            headers: {
+              Connection: "close",
+            },
+          })
+          .send({
+            protocol: "http",
+            domain: "foo.bar",
+          })
+          .report();
+      },
+      {
+        closedConnections: 0,
+      }
+    ),
+    "connection closed, more requests": mock.getContext(
+      "keepAlive",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            protocol: "http",
+            domain: "foo.net",
+            url: "http://foo.net/",
+            headers: {
+              Connection: "close",
+            },
+          })
+          .send({
+            protocol: "http",
+            domain: "foo.net",
+          })
+          .report();
+      },
+      {
+        closedConnections: 1,
+      }
+    ),
+    "connection not closed, more requests": mock.getContext(
+      "keepAlive",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            protocol: "http",
+            domain: "foo.net",
+            url: "http://foo.net/",
+            headers: {},
+          })
+          .send({
+            protocol: "http",
+            domain: "foo.net",
+          })
+          .report();
+      },
+      {
+        closedConnections: 0,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/mainRequest-test.js
+++ b/test/modules/mainRequest-test.js
@@ -1,58 +1,99 @@
 /**
  * Tests mainRequest module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('mainRequest').
-addBatch({
-	'redirect request': mock.getContext('mainRequest', function(phantomas) {
-		return phantomas.
-		recv({}, {
-			status: 301
-		}).
-		responseEnd({}, {
-			status: 200
-		}).
-		report();
-	}, {
-		'statusCodesTrail': '301,200'
-	}),
-	'long redirect request': mock.getContext('mainRequest', function(phantomas) {
-		return phantomas.
-		recv({}, {
-			status: 301
-		}).
-		recv({}, {
-			status: 302
-		}).
-		responseEnd({}, {
-			status: 404
-		}).
-		report();
-	}, {
-		'statusCodesTrail': '301,302,404'
-	}),
-	'non-redirect (e.g. terminal) first request': mock.getContext('mainRequest', function(phantomas) {
-		return phantomas.
-		responseEnd({}, {
-			status: 200
-		}).
-		report();
-	}, {
-		'statusCodesTrail': '200'
-	}),
-	'multiple requests': mock.getContext('mainRequest', function(phantomas) {
-		return phantomas.
-		responseEnd({}, {
-			status: 200
-		}).
-		recv({}, {
-			status: 404
-		}).
-		report();
-	}, {
-		'statusCodesTrail': '200'
-	})
-}).
-export(module);
+vows
+  .describe("mainRequest")
+  .addBatch({
+    "redirect request": mock.getContext(
+      "mainRequest",
+      function (phantomas) {
+        return phantomas
+          .recv(
+            {},
+            {
+              status: 301,
+            }
+          )
+          .responseEnd(
+            {},
+            {
+              status: 200,
+            }
+          )
+          .report();
+      },
+      {
+        statusCodesTrail: "301,200",
+      }
+    ),
+    "long redirect request": mock.getContext(
+      "mainRequest",
+      function (phantomas) {
+        return phantomas
+          .recv(
+            {},
+            {
+              status: 301,
+            }
+          )
+          .recv(
+            {},
+            {
+              status: 302,
+            }
+          )
+          .responseEnd(
+            {},
+            {
+              status: 404,
+            }
+          )
+          .report();
+      },
+      {
+        statusCodesTrail: "301,302,404",
+      }
+    ),
+    "non-redirect (e.g. terminal) first request": mock.getContext(
+      "mainRequest",
+      function (phantomas) {
+        return phantomas
+          .responseEnd(
+            {},
+            {
+              status: 200,
+            }
+          )
+          .report();
+      },
+      {
+        statusCodesTrail: "200",
+      }
+    ),
+    "multiple requests": mock.getContext(
+      "mainRequest",
+      function (phantomas) {
+        return phantomas
+          .responseEnd(
+            {},
+            {
+              status: 200,
+            }
+          )
+          .recv(
+            {},
+            {
+              status: 404,
+            }
+          )
+          .report();
+      },
+      {
+        statusCodesTrail: "200",
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/mock.js
+++ b/test/modules/mock.js
@@ -1,199 +1,207 @@
 /**
  * Defines phantomas global API mock
  */
-var assert = require('assert'),
-	debug = require('debug'),
-	noop = function() {};
+var assert = require("assert"),
+  debug = require("debug"),
+  noop = function () {};
 
-var phantomas = function(name) {
-	this.emitter = new(require('events').EventEmitter)();
-	this.wasEmitted = {};
-	this.metrics = {};
-	this.offenders = {};
+var phantomas = function (name) {
+  this.emitter = new (require("events").EventEmitter)();
+  this.wasEmitted = {};
+  this.metrics = {};
+  this.offenders = {};
 
-	this.log = debug('phantomas:test:' + name);
+  this.log = debug("phantomas:test:" + name);
 };
 
 phantomas.prototype = {
-	require: function(name) {
-		return require(name);
-	},
+  require: function (name) {
+    return require(name);
+  },
 
-	getParam: noop,
+  getParam: noop,
 
-	// events
-	emit: function( /* eventName, arg1, arg2, ... */ ) { //console.log('emit: ' + arguments[0]);
-		try {
-			this.log('emit: %j', Array.prototype.slice.apply(arguments));
-			this.emitter.emit.apply(this.emitter, arguments);
-		} catch (ex) {
-			console.log(ex);
-		}
+  // events
+  emit: function (/* eventName, arg1, arg2, ... */) {
+    //console.log('emit: ' + arguments[0]);
+    try {
+      this.log("emit: %j", Array.prototype.slice.apply(arguments));
+      this.emitter.emit.apply(this.emitter, arguments);
+    } catch (ex) {
+      console.log(ex);
+    }
 
-		this.wasEmitted[arguments[0]] = true;
-		return this;
-	},
-	emitInternal: function() {
-		this.emit.apply(this, arguments);
-	},
-	on: function(ev, fn) { //console.log('on: ' + ev);
-		this.emitter.on(ev, fn);
-	},
-	once: function(ev, fn) {
-		this.emitter.once(ev, fn);
-	},
+    this.wasEmitted[arguments[0]] = true;
+    return this;
+  },
+  emitInternal: function () {
+    this.emit.apply(this, arguments);
+  },
+  on: function (ev, fn) {
+    //console.log('on: ' + ev);
+    this.emitter.on(ev, fn);
+  },
+  once: function (ev, fn) {
+    this.emitter.once(ev, fn);
+  },
 
-	emitted: function(ev) {
-		return this.wasEmitted[ev] === true;
-	},
+  emitted: function (ev) {
+    return this.wasEmitted[ev] === true;
+  },
 
-	// metrics
-	setMetric: function(name, value) {
-		this.metrics[name] = (typeof value !== 'undefined') ? value : 0;
-	},
-	setMetricEvaluate: noop,
-	incrMetric: function(name, incr /* =1 */ ) {
-		this.metrics[name] = (this.metrics[name] || 0) + (incr || 1);
-	},
-	getMetric: function(name) {
-		return this.metrics[name];
-	},
-	hasValue: function(name, val) {
-		return this.getMetric(name) === val;
-	},
+  // metrics
+  setMetric: function (name, value) {
+    this.metrics[name] = typeof value !== "undefined" ? value : 0;
+  },
+  setMetricEvaluate: noop,
+  incrMetric: function (name, incr /* =1 */) {
+    this.metrics[name] = (this.metrics[name] || 0) + (incr || 1);
+  },
+  getMetric: function (name) {
+    return this.metrics[name];
+  },
+  hasValue: function (name, val) {
+    return this.getMetric(name) === val;
+  },
 
-	addOffender: function(name, value) {
-		this.offenders[name] = this.offenders[name] || [];
-		this.offenders[name].push(value);
-	},
+  addOffender: function (name, value) {
+    this.offenders[name] = this.offenders[name] || [];
+    this.offenders[name].push(value);
+  },
 
-	getOffenders: function(name) {
-		return this.offenders[name];
-	},
+  getOffenders: function (name) {
+    return this.offenders[name];
+  },
 
-	// mock core phantomas events
-	sendRequest: function(req) {
-		req = req || {};
-		req._requestId = req._requestId || 1;
-		req.method = req.method || 'GET';
-		req.url = req.url || 'http://example.com';
-		req.headers = req.headers || [];
-		req.timing = {};
-		req.headersText = '';
+  // mock core phantomas events
+  sendRequest: function (req) {
+    req = req || {};
+    req._requestId = req._requestId || 1;
+    req.method = req.method || "GET";
+    req.url = req.url || "http://example.com";
+    req.headers = req.headers || [];
+    req.timing = {};
+    req.headersText = "";
 
-		this.log('sendRequest: %j', req);
+    this.log("sendRequest: %j", req);
 
-		try {
-			this.emitter.emit('request', req);
-			this.emitter.emit('response', req);
-		} catch (ex) {
-			console.log(ex);
-		}
+    try {
+      this.emitter.emit("request", req);
+      this.emitter.emit("response", req);
+    } catch (ex) {
+      console.log(ex);
+    }
 
-		return this;
-	},
-	recvRequest: function(req) {
-		req = req || {};
-		req.stage = req.stage || 'end';
-		req.id = req.id || 1;
-		req.method = req.method || 'GET';
-		req.url = req.url || 'http://example.com';
-		req.headers = req.headers || [];
+    return this;
+  },
+  recvRequest: function (req) {
+    req = req || {};
+    req.stage = req.stage || "end";
+    req.id = req.id || 1;
+    req.method = req.method || "GET";
+    req.url = req.url || "http://example.com";
+    req.headers = req.headers || [];
 
-		this.log('recvRequest: %j', req);
+    this.log("recvRequest: %j", req);
 
-		try {
-			this.emitter.emit('onResourceRequested', req);
-			this.emitter.emit('onResourceReceived', req);
-		} catch (ex) {
-			console.log(ex);
-		}
+    try {
+      this.emitter.emit("onResourceRequested", req);
+      this.emitter.emit("onResourceReceived", req);
+    } catch (ex) {
+      console.log(ex);
+    }
 
-		return this;
-	},
+    return this;
+  },
 
-	// phantomas-specific events
-	send: function(entry, res) {
-		return this.emit('send', entry || {}, res || {});
-	},
+  // phantomas-specific events
+  send: function (entry, res) {
+    return this.emit("send", entry || {}, res || {});
+  },
 
-	recv: function(entry, res) {
-		return this.emit('recv', entry || {}, res || {});
-	},
+  recv: function (entry, res) {
+    return this.emit("recv", entry || {}, res || {});
+  },
 
-	responseEnd: function(entry, res) {
-		return this.emit('responseEnd', entry || {}, res || {});
-	},
+  responseEnd: function (entry, res) {
+    return this.emit("responseEnd", entry || {}, res || {});
+  },
 
-	report: function() {
-		this.emit('report');
-		this.log('metrics: %j', this.metrics);
+  report: function () {
+    this.emit("report");
+    this.log("metrics: %j", this.metrics);
 
-		return this;
-	},
+    return this;
+  },
 
-	// noop mocks
-	log: noop,
-	echo: noop,
-	evaluate: noop,
-	injectJs: noop
+  // noop mocks
+  log: noop,
+  echo: noop,
+  evaluate: noop,
+  injectJs: noop,
 };
 
 function initModule(name, isCore) {
-	var instance, def;
+  var instance, def;
 
-	try {
-		instance = new phantomas(name);
-		def = require('../../' + (isCore ? 'core/modules' : 'modules') + '/' + name + '/' + name + '.js');
+  try {
+    instance = new phantomas(name);
+    def = require("../../" +
+      (isCore ? "core/modules" : "modules") +
+      "/" +
+      name +
+      "/" +
+      name +
+      ".js");
 
-		new(def)(instance);
-	} catch (ex) {
-		console.log(ex);
-	}
+    new def(instance);
+  } catch (ex) {
+    console.log(ex);
+  }
 
-	return instance;
+  return instance;
 }
 
 function assertMetric(name, value) {
-	return function(phantomas) {
-		assert.strictEqual(phantomas.getMetric(name), value);
-	};
+  return function (phantomas) {
+    assert.strictEqual(phantomas.getMetric(name), value);
+  };
 }
 
 function assertOffender(name, value) {
-	return function(phantomas) {
-		assert.deepStrictEqual(phantomas.getOffenders(name), value);
-	};
+  return function (phantomas) {
+    assert.deepStrictEqual(phantomas.getOffenders(name), value);
+  };
 }
 
 module.exports = {
-	initModule: function(name) {
-		return initModule(name);
-	},
-	initCoreModule: function(name) {
-		return initModule(name, true /* core */ );
-	},
+  initModule: function (name) {
+    return initModule(name);
+  },
+  initCoreModule: function (name) {
+    return initModule(name, true /* core */);
+  },
 
-	assertMetric: assertMetric,
+  assertMetric: assertMetric,
 
-	getContext: function(moduleName, topic, metricsCheck, offendersCheck) {
-		var phantomas = initModule(moduleName),
-			context = {};
+  getContext: function (moduleName, topic, metricsCheck, offendersCheck) {
+    var phantomas = initModule(moduleName),
+      context = {};
 
-		context.topic = function() {
-			return topic(phantomas);
-		};
+    context.topic = function () {
+      return topic(phantomas);
+    };
 
-		Object.keys(metricsCheck || {}).forEach(function(name) {
-			var check = 'sets "' + name + '" metric correctly';
-			context[check] = assertMetric(name, metricsCheck[name]);
-		});
+    Object.keys(metricsCheck || {}).forEach(function (name) {
+      var check = 'sets "' + name + '" metric correctly';
+      context[check] = assertMetric(name, metricsCheck[name]);
+    });
 
-		Object.keys(offendersCheck || {}).forEach(function(name) {
-			var check = 'sets "' + name + '" offender(s) correctly';
-			context[check] = assertOffender(name, offendersCheck[name]);
-		});
+    Object.keys(offendersCheck || {}).forEach(function (name) {
+      var check = 'sets "' + name + '" offender(s) correctly';
+      context[check] = assertOffender(name, offendersCheck[name]);
+    });
 
-		return context;
-	}
+    return context;
+  },
 };

--- a/test/modules/redirects-test.js
+++ b/test/modules/redirects-test.js
@@ -1,26 +1,37 @@
 /**
  * Test redirects module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('redirects').
-addBatch({
-	'HTTP 301/302': mock.getContext('redirects', function(phantomas) {
-		return phantomas.recv({
-			isRedirect: true,
-			timeToLastByte: 20,
-			headers: {}
-		}).report();
-	}, {
-		'redirects': 1,
-		'redirectsTime': 20
-	}),
-	'HTTP 200': mock.getContext('redirects', function(phantomas) {
-		return phantomas.recv().report();
-	}, {
-		'redirects': 0,
-		'redirectsTime': 0
-	})
-}).
-export(module);
+vows
+  .describe("redirects")
+  .addBatch({
+    "HTTP 301/302": mock.getContext(
+      "redirects",
+      function (phantomas) {
+        return phantomas
+          .recv({
+            isRedirect: true,
+            timeToLastByte: 20,
+            headers: {},
+          })
+          .report();
+      },
+      {
+        redirects: 1,
+        redirectsTime: 20,
+      }
+    ),
+    "HTTP 200": mock.getContext(
+      "redirects",
+      function (phantomas) {
+        return phantomas.recv().report();
+      },
+      {
+        redirects: 0,
+        redirectsTime: 0,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/requestsMonitor-test.js
+++ b/test/modules/requestsMonitor-test.js
@@ -1,55 +1,62 @@
 /**
  * Test requestsMonitor core module
  */
-var vows = require('vows'),
-	assert = require('assert'),
-	mock = require('./mock'),
-	extend = require('util')._extend;
+var vows = require("vows"),
+  assert = require("assert"),
+  mock = require("./mock"),
+  extend = require("util")._extend;
 
 function sendReq(url, extra) {
-	return function() {
-		var phantomas = mock.initCoreModule('requestsMonitor'),
-			ret = false;
+  return function () {
+    var phantomas = mock.initCoreModule("requestsMonitor"),
+      ret = false;
 
-		phantomas.on('recv', entry => {
-			ret = entry;
-		});
-		phantomas.sendRequest(extend({
-			url: url
-		}, extra || {}));
-		return ret;
-	};
+    phantomas.on("recv", (entry) => {
+      ret = entry;
+    });
+    phantomas.sendRequest(
+      extend(
+        {
+          url: url,
+        },
+        extra || {}
+      )
+    );
+    return ret;
+  };
 }
 
 function sendContentType(contentType, url) {
-	return sendReq(url, {
-		headers: {'Content-Type': contentType}
-	});
+  return sendReq(url, {
+    headers: { "Content-Type": contentType },
+  });
 }
 
 function assertField(name, value) {
-	return function(entry) {
-		assert.strictEqual(entry[name], value);
-	};
+  return function (entry) {
+    assert.strictEqual(entry[name], value);
+  };
 }
 
-vows.describe('requestMonitor').addBatch({
-	'events on send are fired': {
-		topic: function() {
-			var phantomas = mock.initCoreModule('requestsMonitor');
-			phantomas.sendRequest();
-			return phantomas;
-		},
-		/**
+vows
+  .describe("requestMonitor")
+  .addBatch({
+    "events on send are fired": {
+      topic: function () {
+        var phantomas = mock.initCoreModule("requestsMonitor");
+        phantomas.sendRequest();
+        return phantomas;
+      },
+      /**
 		'beforeSend is fired': function(phantomas) {
 			assert.isTrue(phantomas.emitted('beforeSend'));
 		},
 		**/
-		'send is fired': function(phantomas) {
-			assert.isTrue(phantomas.emitted('send'));
-		}
-	},
-	/**
+      "send is fired": function (phantomas) {
+        assert.isTrue(phantomas.emitted("send"));
+      },
+    },
+    /**
 	'request can be aborted': {
 		topic: function() {
 			var phantomas = mock.initCoreModule('requestsMonitor');
@@ -67,20 +74,20 @@ vows.describe('requestMonitor').addBatch({
 		}
 	},
 	**/
-	'URLs are properly parsed when sent': {
-		topic: sendReq('http://example.com/foo?bar=test&a=b'),
-		'protocol is set': assertField('protocol', 'http'),
-		'domain is set': assertField('domain', 'example.com'),
-		'query is set': assertField('query', 'bar=test&a=b'),
-		'isSSL is not set': assertField('isSSL', undefined),
-		'isBase64 is not set': assertField('isBase64', undefined)
-	},
-	'HTTPS is property detected': {
-		topic: sendReq('https://example.com/foo?bar=test&a=b'),
-		'protocol is set': assertField('protocol', 'https'),
-		'isSSL is set': assertField('isSSL', true)
-	},
-	/**
+    "URLs are properly parsed when sent": {
+      topic: sendReq("http://example.com/foo?bar=test&a=b"),
+      "protocol is set": assertField("protocol", "http"),
+      "domain is set": assertField("domain", "example.com"),
+      "query is set": assertField("query", "bar=test&a=b"),
+      "isSSL is not set": assertField("isSSL", undefined),
+      "isBase64 is not set": assertField("isBase64", undefined),
+    },
+    "HTTPS is property detected": {
+      topic: sendReq("https://example.com/foo?bar=test&a=b"),
+      "protocol is set": assertField("protocol", "https"),
+      "isSSL is set": assertField("isSSL", true),
+    },
+    /**
 	'base64-encoded data is property detected': {
 		topic: recvReq('data:image/png;base64,iVBORw0KGgoAAAA', {}, 'base64recv'),
 		'protocol is not set': assertField('protocol', false),
@@ -89,135 +96,142 @@ vows.describe('requestMonitor').addBatch({
 		'isBase64 is set': assertField('isBase64', true)
 	},
 	**/
-}).addBatch({
-	'content type is properly passed': {
-		topic: sendContentType('text/html'),
-		'entry.contentType is set': assertField('contentType', 'text/html')
-	},
-	'HTML is properly detected': {
-		topic: sendContentType('text/html'),
-		'isHTML is set': assertField('isHTML', true)
-	},
-	'XML is properly detected': {
-		topic: sendContentType('text/xml'),
-		'isXML is set': assertField('isXML', true)
-	},
-	'CSS is properly detected': {
-		topic: sendContentType('text/css'),
-		'isCSS is set': assertField('isCSS', true)
-	},
-	'JS is properly detected': {
-		topic: sendContentType('text/javascript'),
-		'isJS is set': assertField('isJS', true)
-	},
-	'JSON is properly detected': {
-		topic: sendContentType('application/json'),
-		'isJSON is set': assertField('isJSON', true)
-	},
-	'PNG image is properly detected': {
-		topic: sendContentType('image/png'),
-		'isImage is set': assertField('isImage', true)
-	},
-	'JPEG image is properly detected': {
-		topic: sendContentType('image/jpeg'),
-		'isImage is set': assertField('isImage', true)
-	},
-	'GIF image is properly detected': {
-		topic: sendContentType('image/gif'),
-		'isImage is set': assertField('isImage', true)
-	},
-	'SVG image is properly detected': {
-		topic: sendContentType('image/svg+xml'),
-		'isImage is set': assertField('isImage', true),
-		'isSVG is set': assertField('isSVG', true)
-	},
-	'WEBP image is properly detected': {
-		topic: sendContentType('image/webp'),
-		'isImage is set': assertField('isImage', true)
-	},
-	'WebM video is properly detected': {
-		topic: sendContentType('video/webm'),
-		'isVideo is set': assertField('isVideo', true)
-	},
-	'WOFF font is properly detected (via MIME)': {
-		topic: sendContentType('application/font-woff'),
-		'isWebFont is set': assertField('isWebFont', true),
-		'isTTF is not set': assertField('isTTF', undefined)
-	},
-	'WOFF2 font is properly detected (via MIME)': {
-		topic: sendContentType('application/font-woff2'),
-		'isWebFont is set': assertField('isWebFont', true),
-		'isTTF is not set': assertField('isTTF', undefined)
-	},
-	'Web font is properly detected (via URL)': {
-		topic: sendContentType('application/octet-stream', 'http://foo.bar/font.otf'),
-		'isWebFont is set': assertField('isWebFont', true),
-		'isTTF is not set': assertField('isTTF', undefined)
-	},
-	'TTF font is properly detected': {
-		topic: sendContentType('application/x-font-ttf'),
-		'isWebFont is set': assertField('isWebFont', true),
-		'isTTF is set': assertField('isTTF', true)
-	},
-	'favicon is properly detected': {
-		topic: sendContentType('image/x-icon'),
-		'isFavicon is set': assertField('isFavicon', true)
-	},
-	'favicon is properly detected (Microsoft\'s MIME type)': {
-		topic: sendContentType('image/vnd.microsoft.icon'),
-		'isFavicon is set': assertField('isFavicon', true)
-	},
-}).addBatch({
-	'redirects are detected (HTTP 301)': {
-		topic: sendReq('', {
-			status: 301
-		}),
-		'isRedirect field is set': assertField('isRedirect', true)
-	},
-	'redirects are detected (HTTP 302)': {
-		topic: sendReq('', {
-			status: 302
-		}),
-		'isRedirect field is set': assertField('isRedirect', true)
-	},
-	'redirects are detected (HTTP 303)': {
-		topic: sendReq('', {
-			status: 303
-		}),
-		'isRedirect field is set': assertField('isRedirect', true)
-	},
-	'redirects are detected (HTTP 200)': {
-		topic: sendReq('', {
-			status: 200
-		}),
-		'isRedirect field is not set': assertField('isRedirect', undefined)
-	}
-}).addBatch({
-	'POST requests are detected': {
-		topic: mock.initCoreModule('requestsMonitor').sendRequest({
-			method: 'POST'
-		}),
-		'postRequests metric is set': mock.assertMetric('postRequests', 1)
-	},
-	'not found responses are detected (HTTP 404)': {
-		topic: mock.initCoreModule('requestsMonitor').sendRequest({
-			status: 404
-		}),
-		'notFound metric is set': mock.assertMetric('notFound', 1)
-	},
-	'GZIP responses are detected': {
-		topic: sendReq(undefined, {
-			headers: {'Content-Encoding': 'gzip'}
-		}),
-		'gzip is set': assertField('gzip', true)
-	},
-	'Brotli responses are detected': {
-		topic: sendReq(undefined, {
-			// A format using the Brotli algorithm.
-			// https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed
-			headers: {'content-encoding': 'br'}
-		}),
-		'gzip is set': assertField('gzip', true),
-		'brotli is set': assertField('brotli', true)
-	}
-}).export(module);
+  })
+  .addBatch({
+    "content type is properly passed": {
+      topic: sendContentType("text/html"),
+      "entry.contentType is set": assertField("contentType", "text/html"),
+    },
+    "HTML is properly detected": {
+      topic: sendContentType("text/html"),
+      "isHTML is set": assertField("isHTML", true),
+    },
+    "XML is properly detected": {
+      topic: sendContentType("text/xml"),
+      "isXML is set": assertField("isXML", true),
+    },
+    "CSS is properly detected": {
+      topic: sendContentType("text/css"),
+      "isCSS is set": assertField("isCSS", true),
+    },
+    "JS is properly detected": {
+      topic: sendContentType("text/javascript"),
+      "isJS is set": assertField("isJS", true),
+    },
+    "JSON is properly detected": {
+      topic: sendContentType("application/json"),
+      "isJSON is set": assertField("isJSON", true),
+    },
+    "PNG image is properly detected": {
+      topic: sendContentType("image/png"),
+      "isImage is set": assertField("isImage", true),
+    },
+    "JPEG image is properly detected": {
+      topic: sendContentType("image/jpeg"),
+      "isImage is set": assertField("isImage", true),
+    },
+    "GIF image is properly detected": {
+      topic: sendContentType("image/gif"),
+      "isImage is set": assertField("isImage", true),
+    },
+    "SVG image is properly detected": {
+      topic: sendContentType("image/svg+xml"),
+      "isImage is set": assertField("isImage", true),
+      "isSVG is set": assertField("isSVG", true),
+    },
+    "WEBP image is properly detected": {
+      topic: sendContentType("image/webp"),
+      "isImage is set": assertField("isImage", true),
+    },
+    "WebM video is properly detected": {
+      topic: sendContentType("video/webm"),
+      "isVideo is set": assertField("isVideo", true),
+    },
+    "WOFF font is properly detected (via MIME)": {
+      topic: sendContentType("application/font-woff"),
+      "isWebFont is set": assertField("isWebFont", true),
+      "isTTF is not set": assertField("isTTF", undefined),
+    },
+    "WOFF2 font is properly detected (via MIME)": {
+      topic: sendContentType("application/font-woff2"),
+      "isWebFont is set": assertField("isWebFont", true),
+      "isTTF is not set": assertField("isTTF", undefined),
+    },
+    "Web font is properly detected (via URL)": {
+      topic: sendContentType(
+        "application/octet-stream",
+        "http://foo.bar/font.otf"
+      ),
+      "isWebFont is set": assertField("isWebFont", true),
+      "isTTF is not set": assertField("isTTF", undefined),
+    },
+    "TTF font is properly detected": {
+      topic: sendContentType("application/x-font-ttf"),
+      "isWebFont is set": assertField("isWebFont", true),
+      "isTTF is set": assertField("isTTF", true),
+    },
+    "favicon is properly detected": {
+      topic: sendContentType("image/x-icon"),
+      "isFavicon is set": assertField("isFavicon", true),
+    },
+    "favicon is properly detected (Microsoft's MIME type)": {
+      topic: sendContentType("image/vnd.microsoft.icon"),
+      "isFavicon is set": assertField("isFavicon", true),
+    },
+  })
+  .addBatch({
+    "redirects are detected (HTTP 301)": {
+      topic: sendReq("", {
+        status: 301,
+      }),
+      "isRedirect field is set": assertField("isRedirect", true),
+    },
+    "redirects are detected (HTTP 302)": {
+      topic: sendReq("", {
+        status: 302,
+      }),
+      "isRedirect field is set": assertField("isRedirect", true),
+    },
+    "redirects are detected (HTTP 303)": {
+      topic: sendReq("", {
+        status: 303,
+      }),
+      "isRedirect field is set": assertField("isRedirect", true),
+    },
+    "redirects are detected (HTTP 200)": {
+      topic: sendReq("", {
+        status: 200,
+      }),
+      "isRedirect field is not set": assertField("isRedirect", undefined),
+    },
+  })
+  .addBatch({
+    "POST requests are detected": {
+      topic: mock.initCoreModule("requestsMonitor").sendRequest({
+        method: "POST",
+      }),
+      "postRequests metric is set": mock.assertMetric("postRequests", 1),
+    },
+    "not found responses are detected (HTTP 404)": {
+      topic: mock.initCoreModule("requestsMonitor").sendRequest({
+        status: 404,
+      }),
+      "notFound metric is set": mock.assertMetric("notFound", 1),
+    },
+    "GZIP responses are detected": {
+      topic: sendReq(undefined, {
+        headers: { "Content-Encoding": "gzip" },
+      }),
+      "gzip is set": assertField("gzip", true),
+    },
+    "Brotli responses are detected": {
+      topic: sendReq(undefined, {
+        // A format using the Brotli algorithm.
+        // https://fonts.googleapis.com/css?family=IBM+Plex+Sans+Condensed
+        headers: { "content-encoding": "br" },
+      }),
+      "gzip is set": assertField("gzip", true),
+      "brotli is set": assertField("brotli", true),
+    },
+  })
+  .export(module);

--- a/test/modules/requestsStats-test.js
+++ b/test/modules/requestsStats-test.js
@@ -1,44 +1,51 @@
 /**
  * Test requestsStats core module
  */
-var vows = require('vows'),
-	mock = require('./mock');
+var vows = require("vows"),
+  mock = require("./mock");
 
-vows.describe('requestsStats').addBatch({
-	'module': mock.getContext('requestsStats', phantomas => {
-		var requests = [
-			{
-				status: 200,
-				responseSize: 25,
-				timeToFirstByte: 3,
-				timeToLastByte: 5,
-			},
-			{
-				status: 200,
-				responseSize: 2245,
-				timeToFirstByte: 1,
-				timeToLastByte: 11,
-			},
-			{
-				status: 200,
-				responseSize: 205,
-				timeToFirstByte: 2,
-				timeToLastByte: 2,
-			}
-		];
+vows
+  .describe("requestsStats")
+  .addBatch({
+    module: mock.getContext(
+      "requestsStats",
+      (phantomas) => {
+        var requests = [
+          {
+            status: 200,
+            responseSize: 25,
+            timeToFirstByte: 3,
+            timeToLastByte: 5,
+          },
+          {
+            status: 200,
+            responseSize: 2245,
+            timeToFirstByte: 1,
+            timeToLastByte: 11,
+          },
+          {
+            status: 200,
+            responseSize: 205,
+            timeToFirstByte: 2,
+            timeToLastByte: 2,
+          },
+        ];
 
-		requests.forEach(phantomas.recv, phantomas);
+        requests.forEach(phantomas.recv, phantomas);
 
-		// calculate metrics
-		return phantomas.report();
-	}, {
-		'smallestResponse': 25,
-		'biggestResponse': 2245,
-		'fastestResponse': 2,
-		'slowestResponse': 11,
-		'smallestLatency': 1,
-		'biggestLatency': 3,
-		'medianResponse': 5,
-		'medianLatency': 2
-	})
-}).export(module);
+        // calculate metrics
+        return phantomas.report();
+      },
+      {
+        smallestResponse: 25,
+        biggestResponse: 2245,
+        fastestResponse: 2,
+        slowestResponse: 11,
+        smallestLatency: 1,
+        biggestLatency: 3,
+        medianResponse: 5,
+        medianLatency: 2,
+      }
+    ),
+  })
+  .export(module);

--- a/test/modules/staticAssets-test.js
+++ b/test/modules/staticAssets-test.js
@@ -1,128 +1,175 @@
 /**
  * Test staticAssets module
  */
-const vows = require('vows'),
-	mock = require('./mock');
+const vows = require("vows"),
+  mock = require("./mock");
 
-var URL = 'http://example.com/';
+var URL = "http://example.com/";
 
-var suite = vows.describe('staticAssets').
-addBatch({
-	'no-op': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recvRequest().report();
-	}, {
-		'assetsNotGzipped': 0,
-		'assetsWithQueryString': 0,
-		'assetsWithCookies': 0,
-		'smallImages': 0,
-		'smallCssFiles': 0,
-		'smallJsFiles': 0,
-		'multipleRequests': 0
-	}),
-	'with query string': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL + '?foo=bar',
-			status: 200,
-			isCSS: true,
-			type: 'css'
-		}).report();
-	}, {
-		'assetsWithQueryString': 1,
-	}),
-	'with cookies': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			status: 200,
-			isCSS: true,
-			type: 'css',
-			hasCookies: true
-		}).report();
-	}, {
-		'assetsWithCookies': 1,
-	}),
-	'multiple requests': mock.getContext('staticAssets', function(phantomas) {
-		var entry = {
-			url: URL,
-			status: 200,
-			isCSS: true,
-			type: 'css'
-		};
+var suite = vows.describe("staticAssets").addBatch({
+  "no-op": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas.recvRequest().report();
+    },
+    {
+      assetsNotGzipped: 0,
+      assetsWithQueryString: 0,
+      assetsWithCookies: 0,
+      smallImages: 0,
+      smallCssFiles: 0,
+      smallJsFiles: 0,
+      multipleRequests: 0,
+    }
+  ),
+  "with query string": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL + "?foo=bar",
+          status: 200,
+          isCSS: true,
+          type: "css",
+        })
+        .report();
+    },
+    {
+      assetsWithQueryString: 1,
+    }
+  ),
+  "with cookies": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL,
+          status: 200,
+          isCSS: true,
+          type: "css",
+          hasCookies: true,
+        })
+        .report();
+    },
+    {
+      assetsWithCookies: 1,
+    }
+  ),
+  "multiple requests": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      var entry = {
+        url: URL,
+        status: 200,
+        isCSS: true,
+        type: "css",
+      };
 
-		return phantomas.recv(entry).recv(entry).recv(entry).report();
-	}, {
-		'multipleRequests': 1, // one assets loaded multiple times
-	}),
-	'normal images': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			status: 200,
-			isImage: true,
-			type: 'image',
-			responseSize: 32 * 1024
-		}).report();
-	}, {
-		'smallImages': 0,
-	}),
-	'small images': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			status: 200,
-			isImage: true,
-			type: 'image',
-			responseSize: 1024
-		}).report();
-	}, {
-		'smallImages': 1,
-	}),
-	'small CSS': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			status: 200,
-			isCSS: true,
-			type: 'css',
-			responseSize: 1024
-		}).report();
-	}, {
-		'smallCssFiles': 1,
-	}),
-	'small JS': mock.getContext('staticAssets', function(phantomas) {
-		return phantomas.recv({
-			url: URL,
-			status: 200,
-			isJS: true,
-			type: 'js',
-			responseSize: 1024
-		}).report();
-	}, {
-		'smallJsFiles': 1,
-	}),
+      return phantomas.recv(entry).recv(entry).recv(entry).report();
+    },
+    {
+      multipleRequests: 1, // one assets loaded multiple times
+    }
+  ),
+  "normal images": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL,
+          status: 200,
+          isImage: true,
+          type: "image",
+          responseSize: 32 * 1024,
+        })
+        .report();
+    },
+    {
+      smallImages: 0,
+    }
+  ),
+  "small images": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL,
+          status: 200,
+          isImage: true,
+          type: "image",
+          responseSize: 1024,
+        })
+        .report();
+    },
+    {
+      smallImages: 1,
+    }
+  ),
+  "small CSS": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL,
+          status: 200,
+          isCSS: true,
+          type: "css",
+          responseSize: 1024,
+        })
+        .report();
+    },
+    {
+      smallCssFiles: 1,
+    }
+  ),
+  "small JS": mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      return phantomas
+        .recv({
+          url: URL,
+          status: 200,
+          isJS: true,
+          type: "js",
+          responseSize: 1024,
+        })
+        .report();
+    },
+    {
+      smallJsFiles: 1,
+    }
+  ),
 });
 
 // cases for "assetsNotGzipped" metric (issue #515)
 var batch = {};
 
 [
-	'isJS',
-	'isCSS',
-	'isHTML',
-	'isJSON',
-	'isSVG',
-	'isTTF',
-	'isXML',
-	'isFavicon',
-].forEach(function(field) {
-	batch[field.substr(2) + ' should be gzipped'] = mock.getContext('staticAssets', function(phantomas) {
-		var arg = {
-			url: URL,
-			status: 200,
-			type: 'foo',
-		};
-		arg[field] = true;
+  "isJS",
+  "isCSS",
+  "isHTML",
+  "isJSON",
+  "isSVG",
+  "isTTF",
+  "isXML",
+  "isFavicon",
+].forEach(function (field) {
+  batch[field.substr(2) + " should be gzipped"] = mock.getContext(
+    "staticAssets",
+    function (phantomas) {
+      var arg = {
+        url: URL,
+        status: 200,
+        type: "foo",
+      };
+      arg[field] = true;
 
-		return phantomas.recv(arg).report();
-	}, {
-		'assetsNotGzipped': 1,
-	});
+      return phantomas.recv(arg).report();
+    },
+    {
+      assetsNotGzipped: 1,
+    }
+  );
 });
 
 suite.addBatch(batch);

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: "3.2"
 
 services:
   nginx:
@@ -8,5 +8,5 @@ services:
       - "8888:80"
     volumes:
       # see nginx-static.conf
-      - './webroot:/static'
-      - './nginx-static.conf:/etc/nginx/conf.d/nginx-static.conf'
+      - "./webroot:/static"
+      - "./nginx-static.conf:/etc/nginx/conf.d/nginx-static.conf"

--- a/test/results-test.js
+++ b/test/results-test.js
@@ -1,123 +1,144 @@
 /**
  * Tests results wrapper and asserts API
  */
-var vows = require('vows'),
-	assert = require('assert'),
-	Results = require('../core/results');
+var vows = require("vows"),
+  assert = require("assert"),
+  Results = require("../core/results");
 
-var topic = function() {
-	return new Results();
+var topic = function () {
+  return new Results();
 };
 
 // run the test
-vows.describe('Results wrapper').addBatch({
-	'Metrics': {
-		topic: topic,
-		'should be set to zero by default': function(results) {
-			results.setMetric('foo');
-			assert.strictEqual(results.getMetric('foo'), 0);
-		},
-		'should be correctly set': function(results) {
-			results.setMetric('foo', 'bar');
-			assert.strictEqual(results.getMetric('foo'), 'bar');
-		},
-		'avarage should be correctly calculated': () => {
-			const results = new Results();
-			results.addToAvgMetric('foo', 2);
-			results.addToAvgMetric('foo', 1);
-			results.addToAvgMetric('bar', 4);
-			assert.strictEqual(results.getMetric('foo'), 1.5);
-			assert.strictEqual(results.getMetric('bar'), 4);
-		},
-		'should be correctly set (with no casting)': function(results) {
-			results.setMetric('bar', null);
-			assert.strictEqual(results.getMetric('bar'), null);
-		},
-		'should return the list of registered metrics': function(results) {
-			assert.deepEqual(results.getMetricsNames(), ['foo', 'bar']);
-		},
-		'should return the list of metrics and their values': function(results) {
-			assert.deepEqual(results.getMetrics(), {
-				foo: 'bar',
-				bar: null
-			});
-		},
-	},
-	'Offenders': {
-		topic: topic,
-		'should be registered': function(results) {
-			results.addOffender('metric', 'foo');
-			results.addOffender('metric', {'url': 'bar', 'size': 42});
-			results.addOffender('metric2', 'test');
-		},
-		'should be kept in order': function(results) {
-			assert.deepEqual(results.getOffenders('metric'), ['foo', {'url': 'bar', 'size': 42}]);
-			assert.deepEqual(results.getOffenders('metric2'), ['test']);
+vows
+  .describe("Results wrapper")
+  .addBatch({
+    Metrics: {
+      topic: topic,
+      "should be set to zero by default": function (results) {
+        results.setMetric("foo");
+        assert.strictEqual(results.getMetric("foo"), 0);
+      },
+      "should be correctly set": function (results) {
+        results.setMetric("foo", "bar");
+        assert.strictEqual(results.getMetric("foo"), "bar");
+      },
+      "avarage should be correctly calculated": () => {
+        const results = new Results();
+        results.addToAvgMetric("foo", 2);
+        results.addToAvgMetric("foo", 1);
+        results.addToAvgMetric("bar", 4);
+        assert.strictEqual(results.getMetric("foo"), 1.5);
+        assert.strictEqual(results.getMetric("bar"), 4);
+      },
+      "should be correctly set (with no casting)": function (results) {
+        results.setMetric("bar", null);
+        assert.strictEqual(results.getMetric("bar"), null);
+      },
+      "should return the list of registered metrics": function (results) {
+        assert.deepEqual(results.getMetricsNames(), ["foo", "bar"]);
+      },
+      "should return the list of metrics and their values": function (results) {
+        assert.deepEqual(results.getMetrics(), {
+          foo: "bar",
+          bar: null,
+        });
+      },
+    },
+    Offenders: {
+      topic: topic,
+      "should be registered": function (results) {
+        results.addOffender("metric", "foo");
+        results.addOffender("metric", { url: "bar", size: 42 });
+        results.addOffender("metric2", "test");
+      },
+      "should be kept in order": function (results) {
+        assert.deepEqual(results.getOffenders("metric"), [
+          "foo",
+          { url: "bar", size: 42 },
+        ]);
+        assert.deepEqual(results.getOffenders("metric2"), ["test"]);
 
-			assert.equal('undefined', typeof results.getOffenders('metric3'));
-		}
-	},
-	'Asserts': {
-		topic: topic,
-		'should be correctly registered': function(results) {
-			results.setAsserts({
-				foo: 123,
-				bar: 0
-			});
-			assert.deepEqual(results.getAsserts(), {
-				foo: 123,
-				bar: 0
-			});
+        assert.equal("undefined", typeof results.getOffenders("metric3"));
+      },
+    },
+    Asserts: {
+      topic: topic,
+      "should be correctly registered": function (results) {
+        results.setAsserts({
+          foo: 123,
+          bar: 0,
+        });
+        assert.deepEqual(results.getAsserts(), {
+          foo: 123,
+          bar: 0,
+        });
 
-			assert.isTrue(results.hasAssertion('foo'));
-			assert.isFalse(results.hasAssertion('test'));
+        assert.isTrue(results.hasAssertion("foo"));
+        assert.isFalse(results.hasAssertion("test"));
 
-			assert.equal(results.getAssertion('foo'), 123);
-		},
-		'should be correctly processed': function(results) {
-			results.setMetric('foo', 123);
-			assert.isTrue(results.assert('foo'), 'foo lte 123');
+        assert.equal(results.getAssertion("foo"), 123);
+      },
+      "should be correctly processed": function (results) {
+        results.setMetric("foo", 123);
+        assert.isTrue(results.assert("foo"), "foo lte 123");
 
-			results.setMetric('foo', 124);
-			assert.isFalse(results.assert('foo'), 'foo is not lte 123');
+        results.setMetric("foo", 124);
+        assert.isFalse(results.assert("foo"), "foo is not lte 123");
 
-			results.setMetric('test', 200);
-			assert.isFalse(results.hasAssertion('test'), 'no assert for test metric');
-			assert.isTrue(results.assert('test'), 'no assert for test metric');
-		},
-		'can be added on the fly': function(results) {
-			results.setMetric('foo', 125);
-			assert.isFalse(results.assert('foo'), 'foo is lte 123');
+        results.setMetric("test", 200);
+        assert.isFalse(
+          results.hasAssertion("test"),
+          "no assert for test metric"
+        );
+        assert.isTrue(results.assert("test"), "no assert for test metric");
+      },
+      "can be added on the fly": function (results) {
+        results.setMetric("foo", 125);
+        assert.isFalse(results.assert("foo"), "foo is lte 123");
 
-			results.setAssert('foo', 200);
-			assert.isTrue(results.assert('foo'), 'foo is lte 200');
-		},
-		'should always be meet for non-numeric values': function(results) {
-			results.setAssert('foo', 200);
+        results.setAssert("foo", 200);
+        assert.isTrue(results.assert("foo"), "foo is lte 200");
+      },
+      "should always be meet for non-numeric values": function (results) {
+        results.setAssert("foo", 200);
 
-			results.setMetric('foo', '1.9.2');
-			assert.isTrue(results.assert('foo'), 'string assert');
+        results.setMetric("foo", "1.9.2");
+        assert.isTrue(results.assert("foo"), "string assert");
 
-			results.setMetric('foo', false);
-			assert.isTrue(results.assert('foo'), 'bool assert');
-		},
-		'should be correctly reported': function(results) {
-			results.setAsserts({
-				foo: 123,
-				bar: 0
-			});
+        results.setMetric("foo", false);
+        assert.isTrue(results.assert("foo"), "bool assert");
+      },
+      "should be correctly reported": function (results) {
+        results.setAsserts({
+          foo: 123,
+          bar: 0,
+        });
 
-			results.setMetric('foo', 123);
-			results.setMetric('bar', 0);
-			assert.deepEqual(results.getFailedAsserts(), [], 'all asserts are meet');
+        results.setMetric("foo", 123);
+        results.setMetric("bar", 0);
+        assert.deepEqual(
+          results.getFailedAsserts(),
+          [],
+          "all asserts are meet"
+        );
 
-			results.setMetric('foo', 124);
-			results.setMetric('bar', 0);
-			assert.deepEqual(results.getFailedAsserts(), ['foo'], 'one assert is not meet');
+        results.setMetric("foo", 124);
+        results.setMetric("bar", 0);
+        assert.deepEqual(
+          results.getFailedAsserts(),
+          ["foo"],
+          "one assert is not meet"
+        );
 
-			results.setMetric('foo', 124);
-			results.setMetric('bar', 1);
-			assert.deepEqual(results.getFailedAsserts(), ['foo', 'bar'], 'two asserts are not meet');
-		}
-	}
-}).export(module);
+        results.setMetric("foo", 124);
+        results.setMetric("bar", 1);
+        assert.deepEqual(
+          results.getFailedAsserts(),
+          ["foo", "bar"],
+          "two asserts are not meet"
+        );
+      },
+    },
+  })
+  .export(module);


### PR DESCRIPTION
```
DeprecationWarning: Unhandled promise rejections are deprecated
```

See https://github.com/facebook/jest/issues/5311#issuecomment-362752169

```
✗ Errored » Asynchronous Error
      in Integration tests
      in test/integration-test.js
/home/macbre/github/phantomas/test/integration-test.js:19
	throw err;
	^

Error: Protocol error (Performance.getMetrics): Session closed. Most likely the page has been closed.
    at CDPSession.send (/home/macbre/github/phantomas/node_modules/puppeteer/lib/cjs/puppeteer/common/Connection.js:195:35)
    at Page.metrics (/home/macbre/github/phantomas/node_modules/puppeteer/lib/cjs/puppeteer/common/Page.js:699:45)
    at /home/macbre/github/phantomas/lib/browser.js:266:37
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```