### PR TITLE
Browser.init - pass Phantomas options + set ignoreHTTPSErrors when required

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -17,7 +17,7 @@ function Browser() {
 Browser.prototype.bind = (events) => (this.events = events);
 
 // initialize puppeter instance
-Browser.prototype.init = async () => {
+Browser.prototype.init = async (phantomasOptions) => {
   const networkDebug = require("debug")("phantomas:network"),
     env = require("process").env;
 
@@ -28,6 +28,13 @@ Browser.prototype.init = async () => {
       "--disable-dev-shm-usage",
     ],
   };
+
+  // handle Phantomas options
+  //
+  // --ignore-ssl-errors               ignores SSL errors, such as expired or self-signed certificate errors
+  if (phantomasOptions["ignoreSslErrors"]) {
+    options["ignoreHTTPSErrors"] = true;
+  }
 
   // customize path to Chromium binary
   if (env["PHANTOMAS_CHROMIUM_EXECUTABLE"]) {
@@ -47,7 +54,7 @@ Browser.prototype.init = async () => {
   debug("Launching Puppeteer: %j", options);
 
   try {
-    // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#puppeteerlaunchoptions
+    // https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#puppeteerlaunchoptions
     this.browser = await puppeteer.launch(options);
     this.page = await this.browser.newPage();
   } catch (ex) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ function phantomas(url, opts) {
         return reject(Error("URL must be a string"));
       }
 
-      const page = await browser.init(),
+      const page = await browser.init(options),
         debugScope = require("debug")("phantomas:scope:log");
 
       // prepare a small instance object that will be passed to modules and extensions on init


### PR DESCRIPTION
```
$ DEBUG=phantomas:browser* ./bin/phantomas.js https://0.0.0.0:8889 --ignore-ssl-errors
  phantomas:browser Launching Puppeteer: {"args":["--disable-dev-shm-usage"],"ignoreHTTPSErrors":true} +0ms
...
  phantomas:browser console.log: The connection used to load resources from https://0.0.0.0:8889 used TLS 1.0 or TLS 1.1, which are deprecated and will be disabled in the future. Once disabled, users will be prevented from loading these resources. The server should enable TLS 1.2 or later. See https://www.chromestatus.com/feature/5654791610957824 for more information. +35ms
...
  phantomas:browser URL opened: <https://0.0.0.0:8889> +67ms
```

@gmetais - should help you with #816.