### PR TITLE
lazyLoadableImages/scope.js: bind to window.load event

### DIFF
--- a/modules/lazyLoadableImages/scope.js
+++ b/modules/lazyLoadableImages/scope.js
@@ -4,7 +4,7 @@
     "setting up which images can be lazy-loaded analysis"
   );
 
-  window.addEventListener("beforeunload", () => {
+  window.addEventListener("load", () => {
     phantomas.spyEnabled(false, "analyzing which images can be lazy-loaded");
 
     var images = document.body.getElementsByTagName("img"),


### PR DESCRIPTION
Resolves #811

Event handling bound to `beforeunload` was taking to long sometimes (?) causing CI pipeline to fail.

Reverts 6ae4177570c847b336198f1ada2b8326424df5b2 (@gmetais).