### PR TITLE
Fix error with blob urls

### DIFF
--- a/core/modules/requestsMonitor/requestsMonitor.js
+++ b/core/modules/requestsMonitor/requestsMonitor.js
@@ -34,13 +34,11 @@ function parseEntryUrl(entry) {
     entry.domain = false;
     entry.protocol = false;
     entry.isBase64 = true;
-
   } else if (entry.url.indexOf("blob:") === 0) {
     // blob image or video
     entry.domain = false;
     entry.protocol = false;
     entry.isBlob = true;
-
   } else {
     parsed = new URL(entry.url) || {};
 

--- a/core/modules/requestsMonitor/requestsMonitor.js
+++ b/core/modules/requestsMonitor/requestsMonitor.js
@@ -29,8 +29,19 @@ function parseEntryUrl(entry) {
   // asset type
   entry.type = "other";
 
-  if (entry.url.indexOf("data:") !== 0) {
-    // @see https://nodejs.org/api/url.html#url_class_url
+  if (entry.url.indexOf("data:") === 0) {
+    // base64 encoded data
+    entry.domain = false;
+    entry.protocol = false;
+    entry.isBase64 = true;
+
+  } else if (entry.url.indexOf("blob:") === 0) {
+    // blob image or video
+    entry.domain = false;
+    entry.protocol = false;
+    entry.isBlob = true;
+
+  } else {
     parsed = new URL(entry.url) || {};
 
     entry.protocol = parsed.protocol.replace(":", ""); // e.g. "http:"
@@ -40,11 +51,6 @@ function parseEntryUrl(entry) {
     if (entry.protocol === "https") {
       entry.isSSL = true;
     }
-  } else {
-    // base64 encoded data
-    entry.domain = false;
-    entry.protocol = false;
-    entry.isBase64 = true;
   }
 
   return entry;
@@ -230,7 +236,7 @@ module.exports = function (phantomas) {
        *
        * "Throughout this work, time is measured in milliseconds"
        */
-      if (!entry.isBase64) {
+      if (!entry.isBase64 && !entry.isBlob) {
         // resp.timing is empty when handling data:image/gif;base64,R0lGODlhAQABAIABAAAAAP///yH5BAEAAAEALAAAAAABAAEAQAICTAEAOw%3D%3D
         assert(
           typeof resp.timing !== "undefined",
@@ -325,7 +331,7 @@ module.exports = function (phantomas) {
       }
 
       // requests stats
-      if (!entry.isBase64) {
+      if (!entry.isBase64 && !entry.isBlob) {
         phantomas.incrMetric("requests");
         phantomas.addOffender("requests", {
           url: entry.url,
@@ -353,6 +359,8 @@ module.exports = function (phantomas) {
 
       if (entry.isBase64) {
         phantomas.emit("base64recv", entry, resp); // @desc base64-encoded "response" has been received
+      } else if (entry.isBlob) {
+        // Do nothing
       } else {
         phantomas.log(
           "recv: HTTP %d <%s> [%s]",


### PR DESCRIPTION
When a page contains a [blob](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) url (this is quite rare) such as `<img src="blob:http://localhost:8888/99335797-0bf4-46db-bd23-14ed9a1c5549">`, there's an error inside requestMonitor.js:

```
(node:7074) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: resp.timing is empty when handling blob:http://localhost:8888/99335797-0bf4-46db-bd23-14ed9a1c5549
    at /phantomas/core/modules/requestsMonitor/requestsMonitor.js:235:9
    at /phantomas/lib/AwaitEventEmitter.js:15:19
    at Array.forEach (<anonymous>)
    at AwaitEventEmitter.emit (/phantomas/lib/AwaitEventEmitter.js:13:31)
    at Object.onRequestLoaded (/phantomas/lib/browser.js:220:17)
    at /phantomas/lib/browser.js:226:10
    at /phantomas/node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:62
    at Array.map (<anonymous>)
    at Object.emit (/phantomas/node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:43)
    at CDPSession.emit (/phantomas/node_modules/puppeteer/lib/cjs/puppeteer/common/EventEmitter.js:72:22)
```
Here is an example HTML page to test with:

```
<head>
<script>
// From https://gist.github.com/nolanlawson/0eac306e4dac2114c752
function fixBinary (bin) {
    var length = bin.length;
    var buf = new ArrayBuffer(length);
    var arr = new Uint8Array(buf);
    for (var i = 0; i < length; i++) {
        arr[i] = bin.charCodeAt(i);
    }
    return buf;
}

var base64 = 
    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAB1klEQVR42n2TzytEURTHv3e8N1joRhZG" + 
    "zJsoCjsLhcw0jClKWbHwY2GnLGUlIfIP2IjyY2djZTHSMJNQSilFNkz24z0/Ms2MrnvfvMu8mcfZvPvu" + 
    "Pfdzz/mecwgKLNYKb0cFEgXbRvwV2s2HuWazCbzKA5LvNecDXayBjv9NL7tEpSNgbYzQ5kZmAlSXgsGG" + 
    "XmS+MjhKxDHgC+quyaPKQtoPYMQPOh5U9H6tBxF+Icy/aolqAqLP5wjWd5r/Ip3YXVILrF4ZRYAxDhCO" + 
    "J/yCwiMI+/xgjOEzmzIhAio04GeGayIXjQ0wGoAuQ5cmIjh8jNo0GF78QwNhpyvV1O9tdxSSR6PLl51F" + 
    "nIK3uQ4JJQME4sCxCIRxQbMwPNSjqaobsfskm9l4Ky6jvCzWEnDKU1ayQPe5BbN64vYJ2vwO7CIeLIi3" + 
    "ciYAoby0M4oNYBrXgdgAbC/MhGCRhyhCZwrcEz1Ib3KKO7f+2I4iFvoVmIxHigGiZHhPIb0bL1bQApFS" + 
    "9U/AC0ulSXrrhMotka/lQy0Ic08FDeIiAmDvA2HX01W05TopS2j2/H4T6FBVbj4YgV5+AecyLk+Ctvms" + 
    "QWK8WZZ+Hdf7QGu7fobMuZHyq1DoJLvUqQrfM966EU/qYGwAAAAASUVORK5CYII=";

var binary = fixBinary(atob(base64));
var blob = new Blob([binary], {type: "image/png"});
var url = URL.createObjectURL(blob);
var img = new Image();

img.onload = function() {
    URL.revokeObjectURL(this.src);
    document.body.appendChild(this);
}

img.src = url;
</script>
</head>
<body></body>
```

This fix prevents phantomas from trying to analyze the request as a network request.