### PR TITLE
Expose CPU related metrics from page.metrics() as phantomas metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,7 @@
 Modules and metrics
 ===================
 
-This file describes all [`phantomas` modules](https://github.com/macbre/phantomas/tree/devel/modules) (35 of them) and 181 metrics that they emit.
+This file describes all [`phantomas` modules](https://github.com/macbre/phantomas/tree/devel/modules) (36 of them) and 187 metrics that they emit.
 
 When applicable, [offender](https://github.com/macbre/phantomas/issues/140) example is provided.
 
@@ -471,6 +471,35 @@ length of document.cookie (bytes)
 ##### `domainsWithCookies`
 
 number of domains with cookies set (number, with offenders)
+
+
+## [cpuTasks](https://github.com/macbre/phantomas/tree/devel/modules/cpuTasks/cpuTasks.js)
+
+> 
+
+##### `layoutCount`
+
+total number of full or partial page layout (number)
+
+##### `layoutDuration`
+
+combined durations in seconds of all page layouts (ms)
+
+##### `recalcStyleCount`
+
+total number of page style recalculations (number)
+
+##### `recalcStyleDuration`
+
+combined duration in seconds of all page style recalculations (ms)
+
+##### `scriptDuration`
+
+combined duration in seconds of JavaScript execution (ms)
+
+##### `taskDuration`
+
+combined duration in seconds of all tasks performed by the browser (ms)
 
 
 ## [documentHeight](https://github.com/macbre/phantomas/tree/devel/modules/documentHeight/documentHeight.js)

--- a/lib/metadata/metadata.json
+++ b/lib/metadata/metadata.json
@@ -308,6 +308,19 @@
         "documentCookiesCount"
       ]
     },
+    "cpuTasks": {
+      "file": "/modules/cpuTasks/cpuTasks.js",
+      "desc": "",
+      "events": [],
+      "metrics": [
+        "layoutCount",
+        "layoutDuration",
+        "recalcStyleCount",
+        "recalcStyleDuration",
+        "scriptDuration",
+        "taskDuration"
+      ]
+    },
     "documentHeight": {
       "file": "/modules/documentHeight/documentHeight.js",
       "desc": "Measure document height",
@@ -1174,6 +1187,42 @@
       "module": "cookies",
       "testsCovered": false
     },
+    "layoutCount": {
+      "desc": "total number of full or partial page layout",
+      "unit": "number",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
+    "layoutDuration": {
+      "desc": "combined durations of all page layouts",
+      "unit": "ms",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
+    "recalcStyleCount": {
+      "desc": "total number of page style recalculations",
+      "unit": "number",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
+    "recalcStyleDuration": {
+      "desc": "combined duration of all page style recalculations",
+      "unit": "ms",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
+    "scriptDuration": {
+      "desc": "combined duration of JavaScript execution",
+      "unit": "ms",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
+    "taskDuration": {
+      "desc": "combined duration of all tasks performed by the browser",
+      "unit": "ms",
+      "module": "cpuTasks",
+      "testsCovered": false
+    },
     "documentHeight": {
       "desc": "the page height",
       "unit": "px",
@@ -1817,8 +1866,8 @@
       "testsCovered": false
     }
   },
-  "metricsCount": 181,
-  "modulesCount": 35,
+  "metricsCount": 187,
+  "modulesCount": 36,
   "extensionsCount": 12,
   "version": "2.0.0"
 }

--- a/modules/cpuTasks/cpuTasks.js
+++ b/modules/cpuTasks/cpuTasks.js
@@ -1,0 +1,18 @@
+/**
+ * Retrieves stats about layouts, style recalcs and JS execution
+ *
+ * Metrics from https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagemetrics
+ */
+"use strict";
+
+module.exports = function (phantomas) {
+
+  phantomas.on("metrics", (metrics) => {
+    phantomas.setMetric("layoutCount", metrics.LayoutCount); // @desc total number of full or partial page layout
+    phantomas.setMetric("layoutDuration", metrics.LayoutDuration); // @desc combined durations in seconds of all page layouts
+    phantomas.setMetric("recalcStyleCount", metrics.RecalcStyleCount); // @desc total number of page style recalculations
+    phantomas.setMetric("recalcStyleDuration", metrics.RecalcStyleDuration); // @desc combined duration in seconds of all page style recalculations
+    phantomas.setMetric("scriptDuration", metrics.ScriptDuration); // @desc combined duration in seconds of JavaScript execution
+    phantomas.setMetric("taskDuration", metrics.TaskDuration); // @desc combined duration in seconds of all tasks performed by the browser
+  });
+};

--- a/modules/cpuTasks/cpuTasks.js
+++ b/modules/cpuTasks/cpuTasks.js
@@ -7,12 +7,17 @@
 
 module.exports = function (phantomas) {
 
+  // Converts seconds into milliseconds
+  function milliseconds(value) {
+    return Math.round(value * 1000);
+  }
+
   phantomas.on("metrics", (metrics) => {
     phantomas.setMetric("layoutCount", metrics.LayoutCount); // @desc total number of full or partial page layout
-    phantomas.setMetric("layoutDuration", metrics.LayoutDuration); // @desc combined durations in seconds of all page layouts
+    phantomas.setMetric("layoutDuration", milliseconds(metrics.LayoutDuration)); // @desc combined durations of all page layouts
     phantomas.setMetric("recalcStyleCount", metrics.RecalcStyleCount); // @desc total number of page style recalculations
-    phantomas.setMetric("recalcStyleDuration", metrics.RecalcStyleDuration); // @desc combined duration in seconds of all page style recalculations
-    phantomas.setMetric("scriptDuration", metrics.ScriptDuration); // @desc combined duration in seconds of JavaScript execution
-    phantomas.setMetric("taskDuration", metrics.TaskDuration); // @desc combined duration in seconds of all tasks performed by the browser
+    phantomas.setMetric("recalcStyleDuration", milliseconds(metrics.RecalcStyleDuration)); // @desc combined duration of all page style recalculations
+    phantomas.setMetric("scriptDuration", milliseconds(metrics.ScriptDuration)); // @desc combined duration of JavaScript execution
+    phantomas.setMetric("taskDuration", milliseconds(metrics.TaskDuration)); // @desc combined duration of all tasks performed by the browser
   });
 };

--- a/modules/cpuTasks/cpuTasks.js
+++ b/modules/cpuTasks/cpuTasks.js
@@ -6,18 +6,17 @@
 "use strict";
 
 module.exports = function (phantomas) {
-
   // Converts seconds into milliseconds
-  function milliseconds(value) {
+  function ms(value) {
     return Math.round(value * 1000);
   }
 
   phantomas.on("metrics", (metrics) => {
     phantomas.setMetric("layoutCount", metrics.LayoutCount); // @desc total number of full or partial page layout
-    phantomas.setMetric("layoutDuration", milliseconds(metrics.LayoutDuration)); // @desc combined durations of all page layouts
+    phantomas.setMetric("layoutDuration", ms(metrics.LayoutDuration)); // @desc combined durations of all page layouts
     phantomas.setMetric("recalcStyleCount", metrics.RecalcStyleCount); // @desc total number of page style recalculations
-    phantomas.setMetric("recalcStyleDuration", milliseconds(metrics.RecalcStyleDuration)); // @desc combined duration of all page style recalculations
-    phantomas.setMetric("scriptDuration", milliseconds(metrics.ScriptDuration)); // @desc combined duration of JavaScript execution
-    phantomas.setMetric("taskDuration", milliseconds(metrics.TaskDuration)); // @desc combined duration of all tasks performed by the browser
+    phantomas.setMetric("recalcStyleDuration", ms(metrics.RecalcStyleDuration)); // @desc combined duration of style recalculations
+    phantomas.setMetric("scriptDuration", ms(metrics.ScriptDuration)); // @desc combined duration of JavaScript execution
+    phantomas.setMetric("taskDuration", ms(metrics.TaskDuration)); // @desc combined duration of all tasks performed by the browser
   });
 };


### PR DESCRIPTION
This pull request adds 6 new metrics, taken from Puppeteer's page.metrics() values:

- **layoutCount**: total number of full or partial page layout
- **layoutDuration**: combined durations of all page layouts
- **recalcStyleCount**: total number of page style recalculations
- **recalcStyleDuration**: combined duration of all page style recalculations
- **scriptDuration**: combined duration of JavaScript execution
- **taskDuration**: combined duration of all tasks performed by the browser

The `scriptDuration` looks particularly important to me, as pages tend to have more and more JS on the web. More information here: https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagemetrics

Don't hesitate if you'd like me to change things such as metrics names, or if I forgot something.

(I can't add tests, as time-based values fluctuate too much. Count values are more stable, but they might also change with browser updates.)