### PR TITLE
Use Docker layers cache to speed up CI builds

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,9 +9,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+
     - name: Build the Docker image
+      env:
+        # @see https://testdriven.io/blog/faster-ci-builds-with-docker-cache/
+        CACHE_IMAGE: macbre/phantomas:latest
       run: |
-        docker build . --tag ${{ github.repository }}
+        docker pull $CACHE_IMAGE
+        docker build . \
+          --cache-from $CACHE_IMAGE \
+          --tag ${{ github.repository }}
         docker images
 
     - name: Run tests inside the Docker container

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,6 +1,9 @@
 name: Check if a Docker image can be built
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ devel ]
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
See https://testdriven.io/blog/faster-ci-builds-with-docker-cache/