### PR TITLE
Fix object errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,8 +89,13 @@ function phantomas(url, opts) {
 
         // @see https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pageevaluateonnewdocumentpagefunction-args
         injectJs: async (script) => {
-          const debug = require("debug")("phantomas:injectJs"),
-            preloadFile = require("fs").readFileSync(script, "utf8");
+          const debug = require("debug")("phantomas:injectJs");
+
+          // Make sure we're on an HTML document, not an XML document for example
+          const prefix = "if (document.constructor.name === 'HTMLDocument') {",
+            suffix = "}";
+
+          const preloadFile = prefix + require("fs").readFileSync(script, "utf8") + suffix;
 
           await page.evaluateOnNewDocument(preloadFile);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,7 +95,8 @@ function phantomas(url, opts) {
           const prefix = "if (document.constructor.name === 'HTMLDocument') {",
             suffix = "}";
 
-          const preloadFile = prefix + require("fs").readFileSync(script, "utf8") + suffix;
+          const preloadFile =
+            prefix + require("fs").readFileSync(script, "utf8") + suffix;
 
           await page.evaluateOnNewDocument(preloadFile);
 

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -839,6 +839,11 @@
       - { url: "http://127.0.0.1:8888/browser-caching.html", type: "html", size: 517 }
       - { url: "http://127.0.0.1:8888/static/jquery-2.1.1.min.js", type: "js", size: 29734 }
 
+# don't call MutationObserver on <object> tags
+- url: "/svg-as-object.html"
+  metrics:
+    jsErrors: 0
+
 #
 # integration-test-extra section
 #

--- a/test/webroot/svg-as-object.html
+++ b/test/webroot/svg-as-object.html
@@ -1,0 +1,10 @@
+<body>
+    <!-- 
+        Objects should not throw the following JS errors:
+        
+        TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'
+        TypeError: Cannot read property 'scrollHeight' of null
+        TypeError: Cannot read property 'getElementsByTagName' of null
+     -->
+    <object data="/static/example.svg" type="image/svg+xml"></object>
+</body>


### PR DESCRIPTION
Hi there, happy new year!

I've spotted another (rare) error, when a website contains an `<object>` tag, which is for example a way to integrate SVG images: https://css-tricks.com/using-svg/#using-svg-as-an-object

It directly adds 3 JS errors in the `jsErrors` offenders:

```
TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'. 
TypeError: Cannot read property 'scrollHeight' of null
TypeError: Cannot read property 'getElementsByTagName' of null
```

This is due to Puppeteer running `page.evaluateOnNewDocument()` even on non-HTML documents.

My fix automatically adds a test that checks the kind of document inside each new `scope.js` file injected. It might not be the best way to implement this, please tell me if you have better idea!

