### PR TITLE
Fix for neverending runs

### DIFF
--- a/extensions/screenshot/screenshot.js
+++ b/extensions/screenshot/screenshot.js
@@ -40,13 +40,19 @@ module.exports = function (phantomas) {
       };
       phantomas.log("Will take screenshot, options: %j", options);
 
-      // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagescreenshotoptions
-      await page.screenshot(options);
+      try {
+        // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagescreenshotoptions
+        await page.screenshot(options);
 
-      phantomas.log("Screenshot stored in %s", path);
+        phantomas.log("Screenshot stored in %s", path);
 
-      // let clients know that we stored the page source in a file
-      phantomas.emit("screenshot", path);
+        // let clients know that we stored the page source in a file
+        phantomas.emit("screenshot", path);
+      } catch (err) {
+        phantomas.log("Error while taking the screenshot");
+        phantomas.log(err);
+      }
+
       resolve();
     });
   });

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -188,17 +188,29 @@ Browser.prototype.init = async (phantomasOptions) => {
     // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#cdpsessionsendmethod-params
     response.getContent = (async () => {
       networkDebug("Getting content for #%s", data.requestId);
-      const resp = await this.cdp.send("Network.getResponseBody", {
-        requestId: data.requestId,
-      });
-      networkDebug(
-        "Content for #%s received (%d bytes)",
-        data.requestId,
-        resp.body.length
-      );
+      let body = null;
 
-      //console.log('getContent()', resp);
-      return resp.body;
+      try {
+        const resp = await this.cdp.send("Network.getResponseBody", {
+          requestId: data.requestId,
+        });
+        networkDebug(
+          "Content for #%s received (%d bytes)",
+          data.requestId,
+          resp.body.length
+        );
+
+        body = resp.body;
+      } catch (err) {
+        // In case the resource was dumped after a redirect
+        // https://github.com/puppeteer/puppeteer/issues/2258
+        networkDebug(
+          "Could not read the content of #%s. It was probably removed from the browser's buffer by a redirect.",
+          data.requestId
+        );
+      }
+
+      return body;
     }).bind(this);
 
     networkDebug(
@@ -262,11 +274,12 @@ Browser.prototype.visit = (url, waitUntil, timeout) => {
         waitUntil: waitUntil,
         timeout: (timeout || 30) * 1000, // defaults to 30 seconds, provide in miliseconds!
       });
+
+      debug("URL opened: <%s>", url);
     } catch (ex) {
       debug("Opening URL failed: " + ex);
       return reject(ex);
     }
-    debug("URL opened: <%s>", url);
 
     // https://github.com/GoogleChrome/puppeteer/issues/1325#issuecomment-382003386
     // bind to this event when getting "Protocol error (Runtime.callFunctionOn): Target closed."

--- a/modules/analyzeCss/analyzeCss.js
+++ b/modules/analyzeCss/analyzeCss.js
@@ -207,7 +207,11 @@ module.exports = function (phantomas) {
             css = await entry.content();
           }
 
-          analyzeCss(css, entry.url, resolve);
+          if (css) {
+            analyzeCss(css, entry.url, resolve);
+          } else {
+            resolve();
+          }
         })
       );
     });

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -845,6 +845,12 @@
   metrics:
     jsErrors: 0
 
+# screenshot path error
+- url: "/jquery.html"
+  label: "invalid screenshot path"
+  options:
+    screenshot: "non-existing-path/screenshot.png"
+
 #
 # integration-test-extra section
 #

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -506,14 +506,15 @@
     globalVariables: ["a_global", "falsy", "foo"]
     globalVariablesFalsy:
       - { name: "falsy", value: false }
-# JS redirects (#550)
+# JS redirects (#550 + #846)
 - url: "/js-redirect.html"
   metrics:
-    requests: 2
+    requests: 3
     htmlCount: 2
     jsErrors: 0
   options:
     "wait-for-network-idle": true
+    "analyze-css": true
 
 # AJAX requests (#622)
 - url: "/jquery-ajax.html"

--- a/test/webroot/js-redirect.html
+++ b/test/webroot/js-redirect.html
@@ -1,8 +1,13 @@
+<head>
+	<link rel="stylesheet" href="static/style.css" />
+</head>
 <body>
 	<script>
 		var url = '/js-globals.html';
 
-		console.log('Redirecting to %s', url);
-		document.location = url;
+		setTimeout(() => {
+			console.log('Redirecting to %s', url);
+			document.location = url;
+		}, 100);
 	</script>
 </body>


### PR DESCRIPTION
This pull request fixes two bugs that can prevent Phantomas from completing a test when testing some pages (fixes #846).

**First case:** in some cases, a CSS request's content can't be retrieved by the CSS analyzer module. The promise is never resolved, nor rejected, Phantomas is stuck in an infinite loop.

**Second case:** if saving the screenshot on the disk fails, an exception is thrown but not correctly caught and Phantomas is stuck in an infinite loop too.

And I've added test cases for both ;)