### PR TITLE
Improve User Agents

### DIFF
--- a/extensions/userAgent/userAgent.js
+++ b/extensions/userAgent/userAgent.js
@@ -1,5 +1,5 @@
 /**
- * Sets a user agent according to --user-agent or -phone or -tablet options
+ * Sets a user agent according to --user-agent or --phone or --tablet options
  */
 "use strict";
 

--- a/extensions/userAgent/userAgent.js
+++ b/extensions/userAgent/userAgent.js
@@ -31,7 +31,10 @@ module.exports = function (phantomas) {
   // it can contain <Platform>, <BrowserVersion> and <PhantomasVersion> if needed
   const param = phantomas.getParam("user-agent");
   if (typeof param !== "undefined") {
-    phantomas.log('userAgent: --user-agent option detected with value %s', param);
+    phantomas.log(
+      "userAgent: --user-agent option detected with value %s",
+      param
+    );
     userAgent = param;
   }
 
@@ -39,7 +42,7 @@ module.exports = function (phantomas) {
     const browserVersion = await browser.version();
     // browserVersion will look like HeadlessChrome/88.0.4298.0
     // let's keep the number only:
-    const versionNumber = browserVersion.split('/')[1];
+    const versionNumber = browserVersion.split("/")[1];
 
     userAgent = userAgent.replace("<Platform>", platform);
     userAgent = userAgent.replace("<BrowserVersion>", versionNumber);

--- a/extensions/userAgent/userAgent.js
+++ b/extensions/userAgent/userAgent.js
@@ -1,0 +1,52 @@
+/**
+ * Sets a user agent according to --user-agent or -phone or -tablet options
+ */
+"use strict";
+
+module.exports = function (phantomas) {
+  // the user-agent template we use for all emulated devices
+  let userAgent =
+    "Mozilla/5.0 (<Platform>) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/<BrowserVersion> Safari/537.36 Phantomas/<PhantomasVersion>";
+
+  // default platform for desktop
+  let platform = "Windows NT 10.0; Win64; x64";
+
+  // --phone option overwrites the default platform
+  if (
+    phantomas.getParam("phone") === true ||
+    phantomas.getParam("phone-landscape") === true
+  ) {
+    platform = "Linux; Android 10; SM-G981B";
+  }
+
+  // --tablet option overwrites the default platform
+  if (
+    phantomas.getParam("tablet") === true ||
+    phantomas.getParam("tablet-landscape") === true
+  ) {
+    platform = "Linux; Android 10; SM-T870";
+  }
+
+  // if --user-agent option is set, it overwrites --phone and --tablet
+  // it can contain <Platform>, <BrowserVersion> and <PhantomasVersion> if needed
+  const param = phantomas.getParam("user-agent");
+  if (typeof param !== "undefined") {
+    phantomas.log('userAgent: --user-agent option detected with value %s', param);
+    userAgent = param;
+  }
+
+  phantomas.on("init", async (page, browser) => {
+    const browserVersion = await browser.version();
+    // browserVersion will look like HeadlessChrome/88.0.4298.0
+    // let's keep the number only:
+    const versionNumber = browserVersion.split('/')[1];
+
+    userAgent = userAgent.replace("<Platform>", platform);
+    userAgent = userAgent.replace("<BrowserVersion>", versionNumber);
+    userAgent = userAgent.replace("<PhantomasVersion>", phantomas.getVersion());
+
+    // @see // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagesetuseragentuseragent
+    await page.setUserAgent(userAgent);
+    phantomas.log("userAgent set to %s", userAgent);
+  });
+};

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -67,13 +67,6 @@ Browser.prototype.init = async (phantomasOptions) => {
 
   debug("Using binary from: %s", this.browser.process().spawnfile);
 
-  // set a custom user agent, e.g. "phantomas/2.0.0-beta (HeadlessChrome/72.0.3617.0)"
-  // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagesetuseragentuseragent
-  const browserVersion = await this.browser.version();
-  await this.page.setUserAgent(
-    "phantomas/" + VERSION + " (" + browserVersion + ")"
-  );
-
   // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#browserversion
   debug("Original browser: %s", await this.browser.userAgent());
   debug("Viewport: %j", await this.page.viewport());

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -2,8 +2,7 @@
  * Expose puppeteer API and events emitter object for lib/index.js
  */
 const debug = require("debug")("phantomas:browser"),
-  puppeteer = require("puppeteer"),
-  VERSION = require("../package.json").version;
+  puppeteer = require("puppeteer");
 
 function Browser() {
   this.browser = null;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -317,4 +317,6 @@ Browser.prototype.close = async () => {
   debug("Browser closed");
 };
 
+Browser.prototype.getPuppeteerBrowser = () => this.browser;
+
 module.exports = Browser;

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,7 @@ function phantomas(url, opts) {
       debug("Loading modules...");
       loader.loadModules(scope);
 
-      await events.emit("init", page, browser); // @desc Browser's scope and modules are set up, the page is about to be loaded
+      await events.emit("init", page, browser.getPuppeteerBrowser()); // @desc Browser's scope and modules are set up, the page is about to be loaded
 
       // https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pagegotourl-options
       const waitUntil = options["wait-for-network-idle"]

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -707,7 +707,7 @@
   options:
     phone: true
   metrics:
-    userAgent: "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36"
+    device: "Linux; Android 10; SM-G981B"
     viewport: "360x640"
 
 - url: "/devices.html"
@@ -715,7 +715,7 @@
   options:
     "phone-landscape": true
   metrics:
-    userAgent: "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3765.0 Mobile Safari/537.36"
+    device: "Linux; Android 10; SM-G981B"
     viewport: "640x360"
 
 - url: "/devices.html"
@@ -723,7 +723,7 @@
   options:
     tablet: true
   metrics:
-    userAgent: "Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true"
+    device: "Linux; Android 10; SM-T870"
     viewport: "800x1280"
 
 - url: "/devices.html"
@@ -731,7 +731,7 @@
   options:
     "tablet-landscape": true
   metrics:
-    userAgent: "Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true"
+    device: "Linux; Android 10; SM-T870"
     viewport: "1280x800"
 
 # viewport
@@ -865,36 +865,32 @@
 # user-agent
 - url: "/user-agent.html"
   label: "default desktop user agent"
-  offenders:
-    consoleMessages:
-      - 'log:["Device: Windows NT 10.0; Win64; x64"]'
+  metrics:
+    device: 'Windows NT 10.0; Win64; x64'
 
 # user-agent
 - url: "/user-agent.html"
   label: "phone user agent"
   options:
     phone: true
-  offenders:
-    consoleMessages:
-      - 'log:["Device: Linux; Android 10; SM-G981B"]'
+  metrics:
+    device: 'Linux; Android 10; SM-G981B'
 
 #user-agent
 - url: "/user-agent.html"
   label: "tablet user agent"
   options:
     tablet: true
-  offenders:
-    consoleMessages:
-      - 'log:["Device: Linux; Android 10; SM-T870"]'
+  metrics:
+    device: 'Linux; Android 10; SM-T870'
 
 # user-agent
 - url: "/user-agent.html"
   label: "custom user agent"
   options:
     "user-agent": "customized!"
-  offenders:
-    consoleMessages:
-      - 'log:["customized!"]'
+  metric:
+    userAgent: 'customized!'
 
 # user-agent
 - url: "/user-agent.html"
@@ -902,9 +898,8 @@
   options:
     phone: true
     "user-agent": "customized!"
-  offenders:
-    consoleMessages:
-      - 'log:["customized!"]'
+  metric:
+    userAgent: 'customized!'
 
 #
 # integration-test-extra section

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -862,6 +862,50 @@
       - { url: "http://127.0.0.1:8888/static/stickman.webm", size: 3750 }
       - { url: "http://127.0.0.1:8888/static/stickman.mp4", size: 6785 }
 
+# user-agent
+- url: "/user-agent.html"
+  label: "default desktop user agent"
+  offenders:
+    consoleMessages:
+      - 'log:["Device: Windows NT 10.0; Win64; x64"]'
+
+# user-agent
+- url: "/user-agent.html"
+  label: "phone user agent"
+  options:
+    phone: true
+  offenders:
+    consoleMessages:
+      - 'log:["Device: Linux; Android 10; SM-G981B"]'
+
+#user-agent
+- url: "/user-agent.html"
+  label: "tablet user agent"
+  options:
+    tablet: true
+  offenders:
+    consoleMessages:
+      - 'log:["Device: Linux; Android 10; SM-T870"]'
+
+# user-agent
+- url: "/user-agent.html"
+  label: "custom user agent"
+  options:
+    "user-agent": "customized!"
+  offenders:
+    consoleMessages:
+      - 'log:["customized!"]'
+
+# user-agent
+- url: "/user-agent.html"
+  label: "custom user agent (overwrites mobile)"
+  options:
+    phone: true
+    "user-agent": "customized!"
+  offenders:
+    consoleMessages:
+      - 'log:["customized!"]'
+
 #
 # integration-test-extra section
 #

--- a/test/webroot/user-agent.html
+++ b/test/webroot/user-agent.html
@@ -1,13 +1,12 @@
 <body>
     <script>
-        console.log(navigator.userAgent);
-        console.log(window.outerWidth, window.outerHeight);
-
         const match = navigator.userAgent.match(/Mozilla\/5\.0 \((.*)\) AppleWebKit\/(.*) \(KHTML, like Gecko\) Chrome\/(.*) Safari\/(.*) Phantomas\/(.*)/);
 
         (phantomas => {
-            phantomas.setMetric('device', match[1]);
-            phantomas.setMetric('viewport', window.outerWidth + 'x' + window.outerHeight);
+            if (match !== null) {
+                phantomas.setMetric('device', match[1]);    
+            }
+            phantomas.setMetric('userAgent', navigator.userAgent);
         })(window.__phantomas);
     </script>
 </body>


### PR DESCRIPTION
This pull requests fixes #861.

**Changes:**

- The default user agent for desktop is now disguised as a classical (non-headless) Chrome browser on Windows.
- The mobile and tablet user agents look like Chrome browsers on recent devices.
- I've added `Phantomas/2.1.0` at the end of the User Agent string.
- The --user-agent option is back.
- Added tests.

**And a problem:** 

I've noticed that multiple words options in the CLI are automatically converted into camel case by Commander. For example `--user-agent` is converted into `userAgent` and prevents it from working. But this is a larger issue than just User Agent, it happens on all options. Currently, it looks like none of the multiple words options work from the CLI. Should I open a ticket?