### PR TITLE
CI - use macbre/nginx-brotli:1.19.7

### DIFF
--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
   nginx:
     # https://hub.docker.com/r/macbre/nginx-brotli
-    image: macbre/nginx-brotli:1.19.6
+    image: macbre/nginx-brotli:1.19.7
     ports:
       - "8888:80"
       - "8889:443"


### PR DESCRIPTION
https://github.com/macbre/docker-nginx-brotli/releases/tag/v1.19.7