### PR TITLE
Accept absolute paths for screenshots

### DIFF
--- a/extensions/screenshot/screenshot.js
+++ b/extensions/screenshot/screenshot.js
@@ -35,7 +35,11 @@ module.exports = function (phantomas) {
     path = param;
   }
 
-  path = workingDirectory + "/" + path;
+  // deal with relative paths
+  if (path.indexOf("/") !== 0) {
+    path = workingDirectory + "/" + path;
+  }
+
   phantomas.log("Screenshot will be saved in %s", path);
 
   phantomas.on("beforeClose", (page) => {

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -915,7 +915,21 @@
 
 # screenshot
 - url: "/image-scaling.html"
-  label: "image-scaling.html (with --screenshot)"
+  label: "image-scaling.html (with --screenshot true)"
   options:
     screenshot: true
+  assertFunction: screenshot
+
+# screenshot in a folder inside the project
+- url: "/image-scaling.html"
+  label: "image-scaling.html (with --screenshot relative path)"
+  options:
+    screenshot: "screenshot-relative.png"
+  assertFunction: screenshot
+
+# screenshot in a folder outside of the project
+- url: "/image-scaling.html"
+  label: "image-scaling.html (with --screenshot absolute path)"
+  options:
+    screenshot: "/tmp/screenshot-absolute.png"
   assertFunction: screenshot

--- a/test/integration-test-extra.js
+++ b/test/integration-test-extra.js
@@ -24,6 +24,18 @@ function screenshot(phantomas, batch) {
 
   phantomas.on("screenshot", (_path) => {
     path = _path;
+
+    if (path.indexOf("screenshot-relative.png") >= 0) {
+      // If the screenshot path is provided as relative,
+      // it should be inside the project's folder.
+      path = require("process").cwd() + "/screenshot-relative.png";
+    }
+
+    if (path.indexOf("/tmp/screenshot-absolute.png") === 0) {
+      // If the screenshot path starts with a slash,
+      // it should be absolute.
+      path = "/tmp/screenshot-absolute.png";
+    }
   });
 
   batch["PNG file should be saved"] = () => {


### PR DESCRIPTION
Adds the ability to save screenshots with absolute paths. Until now, screenshots could only be saved inside the project's directory, now we can save them to `/tmp/` or `/what/ever/`.

(+ two new tests.)