### PR TITLE
Handle some unhandled exceptions

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -307,13 +307,14 @@ Browser.prototype.close = async () => {
   try {
     // Allow the beforeunload event to be executed
     // https://github.com/puppeteer/puppeteer/blob/v1.11.0/docs/api.md#pagecloseoptions
-    if (this.page) await this.page.close({ runBeforeUnload: true });
+    if (this.page && !this.page.isClosed())
+      await this.page.close({ runBeforeUnload: true });
 
     // The page is closed, let's close the browser
-    if (this.browser) await this.browser.close();
+    if (this.browser && this.browser.isConnected()) await this.browser.close();
   } catch (ex) {
     debug("An exception was raised in Browser.prototype.close(): " + ex);
-    throw ex;
+    debug(ex);
   }
 
   this.events.emit("close"); // @desc Chromium has been closed

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -152,8 +152,18 @@ Browser.prototype.init = async (phantomasOptions) => {
   });
 
   this.onRequestLoaded = (eventName, data) => {
-    var meta = responses[data.requestId],
-      response = meta.response;
+    var meta = responses[data.requestId];
+
+    if (typeof meta === "undefined") {
+      // the browser sometimes looses trace of a request, let's ignore.
+      networkDebug(
+        "Can't find request id %d in previous requests",
+        data.requestId
+      );
+      return;
+    }
+
+    var response = meta.response;
 
     // errorText: 'net::ERR_FAILED' - request is blocked (meta.response will be empty)
     // errorText: 'net::ERR_ABORTED' - HTTP 404
@@ -240,9 +250,10 @@ Browser.prototype.init = async (phantomasOptions) => {
   // Fired when data chunk was received over the network
   this.cdp.on("Network.dataReceived", (data) => {
     networkDebug("Network.dataReceived: %j", data);
-
-    responses[data.requestId]._chunks++;
-    responses[data.requestId]._dataLength += data.dataLength;
+    if (responses[data.requestId]) {
+      responses[data.requestId]._chunks++;
+      responses[data.requestId]._dataLength += data.dataLength;
+    }
   });
 
   return this.page;


### PR DESCRIPTION
Hello!

A bit of context: I'm running Phantomas in a Docker Amazon Lambda image and this environment requires a few adaptations. One of these is that Amazon Lambda hates unhandled exceptions in promises and triggers a general error that ends the process. They probably run something like that:

`process.on('unhandledRejection', () => {
    throw new Error('some error');
});`

So, even if Phantomas continues to work properly in a standard environment, it breaks on Lambda. I've detected and fixed 3 of them in Phantomas' code. This is the purpose of this pull request.



_Note: Lambda also requires a few Chrome tags (see below). Not sure if they have their place inside Phantomas. Maybe as an option, but I don't want to complexify Phantomas with options that no one understands. So I'm not sure what the name of the option could be. Any thougts?_

`--no-sandbox --no-zygote --disable-gpu --single-process`