### PR TITLE
Test using Node.js 16 too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Node.js 16 will be the ‘Current’ release for the next 6 months and then promoted to Long-term Support (LTS) in October 2021.

https://nodejs.medium.com/node-js-16-available-now-7f5099a97e70