### PR TITLE
Tests - use nginx with http/3 support

### DIFF
--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -6,8 +6,9 @@ services:
     image: macbre/nginx-brotli:1.19.6-http3
     ports:
       - "8888:80"
-      - "8889:443/tcp"
-      - "8889:443/udp" # for quic
+      - "8889:443" # for old HTTP/1.1 with old TLS
+      - "9000:444/tcp"
+      - "9000:444/udp" # for quic and http/3
     volumes:
       # see nginx-static.conf
       - "./webroot:/static"

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -2,11 +2,12 @@ version: "3.2"
 
 services:
   nginx:
-    # https://hub.docker.com/r/macbre/nginx-brotli
-    image: macbre/nginx-brotli:1.19.10
+    # https://github.com/macbre/docker-nginx-brotli#quic--http3-support
+    image: macbre/nginx-brotli:1.19.6-http3
     ports:
       - "8888:80"
-      - "8889:443"
+      - "8889:443/tcp"
+      - "8889:443/udp" # for quic
     volumes:
       # see nginx-static.conf
       - "./webroot:/static"

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -33,13 +33,24 @@ server {
 }
 
 server {
-    listen       443 ssl;
+    # quic and http/3
+    listen 443 quic reuseport;
+
+    # http/2
+    listen 443 ssl http2;
+
     server_name  localhost;
 
     ssl_certificate      /etc/nginx/localhost.crt;
     ssl_certificate_key  /etc/nginx/localhost.key;
     ssl_ciphers          HIGH:!aNULL:!MD5;
-    ssl_protocols        TLSv1.1;
+
+    # Enable all TLS versions (TLSv1.3 is required for QUIC).
+    ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+
+    # Add Alt-Svc header to negotiate HTTP/3.
+    # port 8889 is what's presented to the client (see docker compose YAML file)
+    add_header alt-svc 'h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400';
 
     root   /static;
 

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -66,8 +66,8 @@ server {
     ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
     # Add Alt-Svc header to negotiate HTTP/3.
-    # port 8889 is what's presented to the client (see docker compose YAML file)
-    add_header alt-svc 'h3-27=":8889"; ma=86400, h3-28=":8889"; ma=86400, h3-29=":8889"; ma=86400';
+    # port 9000 is what's presented to the client (see docker compose YAML file)
+    add_header alt-svc 'h3-27=":9000"; ma=86400, h3-28=":9000"; ma=86400, h3-29=":9000"; ma=86400';
 
     root   /static;
 

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -33,17 +33,34 @@ server {
 }
 
 server {
-    # quic and http/3
-    listen 443 quic reuseport;
-
-    # http/2
-    listen 443 ssl http2;
-
+    # http/1.1 and old TLS (do not change!)
+    listen       443 ssl;
     server_name  localhost;
 
     ssl_certificate      /etc/nginx/localhost.crt;
     ssl_certificate_key  /etc/nginx/localhost.key;
     ssl_ciphers          HIGH:!aNULL:!MD5;
+    ssl_protocols        TLSv1.1;
+
+    root   /static;
+
+    location / {
+        autoindex on;
+    }
+}
+
+
+server {
+    # quic and http/3
+    listen 444 quic reuseport;
+
+    # http/2 fallback
+    listen 444 ssl http2;
+
+    server_name  localhost;
+
+    ssl_certificate      /etc/nginx/localhost.crt;
+    ssl_certificate_key  /etc/nginx/localhost.key;
 
     # Enable all TLS versions (TLSv1.3 is required for QUIC).
     ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;


### PR DESCRIPTION
See #929 and https://github.com/macbre/docker-nginx-brotli/releases/tag/1.19.6-http3 (https://github.com/macbre/docker-nginx-brotli/pull/35)