### PR TITLE
http/3 protocol support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
+    - name: Run example script
+      env:
+        DEBUG: "phantomas:browser"
+      run: node examples/index.js https://gf.dev/http3-test
+
     - name: Run tests
       run: |
         ./test/server-start.sh

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,12 +2,13 @@
  * Example script that uses phantomas npm module with promise pattern
  */
 const phantomas = require("..");
+const url = process.argv[2] || "http://127.0.0.1:8888/dom-operations.html";
 
 console.log("phantomas v%s loaded from %s", phantomas.version, phantomas.path);
+console.log("Opening <%s> ...", url);
 
-const promise = phantomas("http://127.0.0.1:8888/dom-operations.html", {
-  "analyze-css": true,
-  "assert-requests": 1,
+const promise = phantomas(url, {
+  "ignore-ssl-errors": true,
 });
 
 //console.log('Results: %s', promise);
@@ -36,10 +37,11 @@ promise.on("milestone", (milestone) => {
 
 promise.on("recv", (response) => {
   console.log(
-    "Response: %s %s [%s]",
+    "Response: %s %s [%s %s]",
     response.method,
     response.url,
-    response.contentType
+    response.contentType,
+    response.httpVersion,
   );
 });
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -41,7 +41,7 @@ promise.on("recv", (response) => {
     response.method,
     response.url,
     response.contentType,
-    response.httpVersion,
+    response.httpVersion
   );
 });
 

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -25,6 +25,11 @@ Browser.prototype.init = async (phantomasOptions) => {
       // page.evaluate throw "Protocol error (Runtime.callFunctionOn): Target closed." without the following
       // https://github.com/GoogleChrome/puppeteer/issues/1175#issuecomment-369728215
       "--disable-dev-shm-usage",
+
+      // enable http/3 support
+      // https://www.bram.us/2020/04/08/how-to-enable-http3-in-chrome-firefox-safari/
+      "--enable-quic",
+      "--quic-version=h3-29",
     ],
   };
 

--- a/modules/protocols/protocols.js
+++ b/modules/protocols/protocols.js
@@ -55,7 +55,7 @@ module.exports = function (phantomas) {
   // set metrics
   phantomas.on("report", () => {
     domains.forEach(function (value, key) {
-      // As of 2020, h2 is the latest protocol, h3 is coming
+      // As of 2020, h2 is the latest protocol, h3 is coming in 2021
       if (value.httpVersion.indexOf("http/1") === 0) {
         phantomas.incrMetric("oldHttpProtocol");
         phantomas.addOffender("oldHttpProtocol", {

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -848,7 +848,7 @@
   options:
     ignore-ssl-errors: true
   metrics:
-    mainDomainHttpProtocol: "h3"
+    mainDomainHttpProtocol: "h3-29"
     oldHttpProtocol: 0
     mainDomainTlsProtocol: "QUIC"
     oldTlsProtocol: 0

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -806,6 +806,7 @@
       - "https://httpbin.org/basic-auth/foo/bar"
 
 # protocols
+# http/1.1 (legacy one)
 - url: "https://127.0.0.1:8889"
   label: "localhost but https version"
   options:
@@ -828,6 +829,17 @@
           tlsVersion: "TLS 1.1",
           beforeDomReady: true,
         }
+
+# http/2
+- url: "https://127.0.0.1:9000"
+  label: "localhost h2 version"
+  options:
+    ignore-ssl-errors: true
+  metrics:
+    mainDomainHttpProtocol: "h2"
+    oldHttpProtocol: 0
+    mainDomainTlsProtocol: "TLS 1.3"
+    oldTlsProtocol: 0
 
 # don't count requests cached by browser
 - url: "/browser-caching.html"

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -841,6 +841,18 @@
     mainDomainTlsProtocol: "TLS 1.3"
     oldTlsProtocol: 0
 
+# http/3
+# - url: "https://127.0.0.1:9001" # TODO
+- url: "https://gf.dev/http3-test"
+  label: "h3"
+  options:
+    ignore-ssl-errors: true
+  metrics:
+    mainDomainHttpProtocol: "h3"
+    oldHttpProtocol: 0
+    mainDomainTlsProtocol: "QUIC"
+    oldTlsProtocol: 0
+
 # don't count requests cached by browser
 - url: "/browser-caching.html"
   metrics:

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -7,8 +7,9 @@ services:
     ports:
       - "8888:80"
       - "8889:443" # for old HTTP/1.1 with old TLS
-      - "9000:444/tcp"
-      - "9000:444/udp" # for quic and http/3
+      - "9000:444" # http/2
+      - "9001:445/tcp"
+      - "9001:445/udp" # for quic and http/3
     volumes:
       # see nginx-static.conf
       - "./webroot:/static"

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -82,8 +82,8 @@ server {
     ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
 
     # Add Alt-Svc header to negotiate HTTP/3.
-    # port 9000 is what's presented to the client (see docker compose YAML file)
-    add_header alt-svc 'h3-27=":9000"; ma=86400, h3-28=":9000"; ma=86400, h3-29=":9000"; ma=86400';
+    # port 9001 is what's presented to the client (see docker compose YAML file)
+    add_header alt-svc 'h3-27=":9001"; ma=86400, h3-28=":9001"; ma=86400, h3-29=":9001"; ma=86400';
 
     root   /static;
 

--- a/test/nginx-static.conf
+++ b/test/nginx-static.conf
@@ -51,11 +51,27 @@ server {
 
 
 server {
-    # quic and http/3
-    listen 444 quic reuseport;
-
-    # http/2 fallback
+    # http/2
     listen 444 ssl http2;
+
+    server_name  localhost;
+
+    ssl_certificate      /etc/nginx/localhost.crt;
+    ssl_certificate_key  /etc/nginx/localhost.key;
+
+    root   /static;
+
+    location / {
+        autoindex on;
+    }
+}
+
+
+server {
+    # quic and http/3
+    listen 445 quic;
+    # http/2 fallback
+    listen 445 ssl http2;
 
     server_name  localhost;
 


### PR DESCRIPTION
* [x] nginx `server` with http/3 support (listening on port 9001)
* [x] integration tests entry
* [x] fix `mainDomainHttpProtocol` metric as h/3 is used by subsequent requests for the same domain

```
$ node examples/index.js https://gf.dev/http3-test
phantomas v2.2.0 loaded from /Users/macbre/git/phantomas
Opening <https://gf.dev/http3-test> ...
Response: GET https://gf.dev/http3-test [text/html h2]
Response: GET https://gf.dev/cdn-cgi/apps/head/BbOSJ-ZMRnT-WKwVXSLwrT5XQss.js [application/javascript h2]
Response: GET https://gf.dev/static/css/all.min.css [text/css h2]
Response: GET https://gf.dev/static/images/sections/footer/logo-desktop.svg [image/svg+xml h3-29]
Response: GET https://gf.dev/cdn-cgi/bm/cv/669835187/api.js [text/javascript h3-29]
Response: GET https://gf.dev/static/fonts/geekflare-icons.woff [font/woff h3-29]
...
```

See #929 