### PR TITLE
Added browser storage handling as seperate extension

### DIFF
--- a/bin/program.js
+++ b/bin/program.js
@@ -69,11 +69,11 @@ function getProgram() {
       "specifies the file name to store the persistent Cookies"
     )
     .option(
-      "--local-storage <storage>",
+      "--local-storage <values>",
       'ability to set a local storage, key-value pairs (e.g. "bar=foo;domain=url")'
     )
     .option(
-      "--session-storage <storage>",
+      "--session-storage <values>",
       'ability to set a session storage, key-value pairs (e.g. "bar=foo;domain=url")'
     )
     .option(

--- a/bin/program.js
+++ b/bin/program.js
@@ -69,6 +69,14 @@ function getProgram() {
       "specifies the file name to store the persistent Cookies"
     )
     .option(
+      "--local-storage <storage>",
+      'ability to set a local storage, key-value pairs (e.g. "bar=foo;domain=url")'
+    )
+    .option(
+      "--session-storage <storage>",
+      'ability to set a session storage, key-value pairs (e.g. "bar=foo;domain=url")'
+    )
+    .option(
       "--ignore-ssl-errors",
       "ignores SSL errors, such as expired or self-signed certificate errors"
     )

--- a/extensions/pageStorage/pageStorage.js
+++ b/extensions/pageStorage/pageStorage.js
@@ -4,51 +4,79 @@
 "use strict";
 
 module.exports = function (phantomas) {
+  const SESSION_STORAGE = "session-storage",
+    LOCAL_STORAGE = "local-storage";
 
-    const 
-        SESSION_STORAGE = "sessionStorage",
-        LOCAL_STORAGE = "localStorage";
+  phantomas.on("init", async (page) => {
+    let sessionStorage = phantomas.getParam(SESSION_STORAGE, false);
+    let localStorage = phantomas.getParam(LOCAL_STORAGE, false);
 
-    phantomas.on("init", async (page) => {
-        const sessionStorage = phantomas.getParam(SESSION_STORAGE);
-        const localStorage = phantomas.getParam(LOCAL_STORAGE);
-
-        if (sessionStorage) {
-            phantomas.log("Injecting sessionStorage: %j", JSON.stringify(sessionStorage));
-            await injectStorage(page, sessionStorage, SESSION_STORAGE);
-        }
-        if (localStorage) {
-            phantomas.log("Injecting localStorag: %j", JSON.stringify(localStorage));
-            await injectStorage(page, localStorage, LOCAL_STORAGE);
-        }
-    });
-
-    /**
-     * Inject the given storage into the specified page storage.
-     * Either localStorage or sessionStorage
-     * 
-     * @param {Page} page in which page the storage should be injected
-     * @param {Object} storage the JSON object consisting of the storage keys and values
-     * @param {string} storageType either localStorage or sessionStorage
-     */
-    async function injectStorage(page, storage, storageType) {
-        if (!page || !storage || !storageType) {
-            return;
-        }
-
-        await page.evaluateOnNewDocument((storage, storageType, SESSION_STORAGE, LOCAL_STORAGE) => {
-            const keys = Object.keys(storage);
-            const values = Object.values(storage);
-            if (storageType === SESSION_STORAGE) {
-                for (let i = 0; i < keys.length; i++) {
-                    sessionStorage.setItem(keys[i], values[i]);
-                }
-            }
-            if (storageType === LOCAL_STORAGE) {
-                for (let i = 0; i < keys.length; i++) {
-                    localStorage.setItem(keys[i], values[i]);
-                }
-            }
-        }, storage, storageType, SESSION_STORAGE, LOCAL_STORAGE);
+    // Mapping given "storage-string" to json object if string has been given
+    if (typeof sessionStorage == "string" || sessionStorage instanceof String) {
+      sessionStorage = parseStorage(sessionStorage);
     }
+
+    if (typeof localStorage == "string" || localStorage instanceof String) {
+      localStorage = parseStorage(localStorage);
+    }
+
+    if (sessionStorage) {
+      phantomas.log(
+        "Injecting sessionStorage: %j",
+        JSON.stringify(sessionStorage)
+      );
+      await injectStorage(page, sessionStorage, SESSION_STORAGE);
+    }
+    if (localStorage) {
+      phantomas.log("Injecting localStorag: %j", JSON.stringify(localStorage));
+      await injectStorage(page, localStorage, LOCAL_STORAGE);
+    }
+  });
+
+  function parseStorage(storageString) {
+    // --sessionStorage='bar=foo;domain=url'
+    // --localStorage='bar=fooLocal;domain=urlLocal'
+    var storageMap = {};
+    storageString.split(";").forEach(function (singleEntry) {
+      var entryKeyValue = singleEntry.split("=");
+      storageMap[entryKeyValue[0]] = entryKeyValue[1];
+    });
+    return storageMap;
+  }
+
+  /**
+   * Inject the given storage into the specified page storage.
+   * Either localStorage or sessionStorage
+   *
+   * @param {Page} page in which page the storage should be injected
+   * @param {Object} storage the JSON object consisting of the storage keys and values
+   * @param {string} storageType either localStorage or sessionStorage
+   */
+  async function injectStorage(page, storage, storageType) {
+    if (!page || !storage || !storageType) {
+      return;
+    }
+
+    /* istanbul ignore next */
+    await page.evaluateOnNewDocument(
+      (storage, storageType, SESSION_STORAGE, LOCAL_STORAGE) => {
+        const keys = Object.keys(storage);
+        const values = Object.values(storage);
+        if (storageType === SESSION_STORAGE) {
+          for (let i = 0; i < keys.length; i++) {
+            sessionStorage.setItem(keys[i], values[i]);
+          }
+        }
+        if (storageType === LOCAL_STORAGE) {
+          for (let i = 0; i < keys.length; i++) {
+            localStorage.setItem(keys[i], values[i]);
+          }
+        }
+      },
+      storage,
+      storageType,
+      SESSION_STORAGE,
+      LOCAL_STORAGE
+    );
+  }
 };

--- a/extensions/pageStorage/pageStorage.js
+++ b/extensions/pageStorage/pageStorage.js
@@ -1,0 +1,54 @@
+/**
+ * Support for session-/localStorage injection.
+ */
+"use strict";
+
+module.exports = function (phantomas) {
+
+    const 
+        SESSION_STORAGE = "sessionStorage",
+        LOCAL_STORAGE = "localStorage";
+
+    phantomas.on("init", async (page) => {
+        const sessionStorage = phantomas.getParam(SESSION_STORAGE);
+        const localStorage = phantomas.getParam(LOCAL_STORAGE);
+
+        if (sessionStorage) {
+            phantomas.log("Injecting sessionStorage: %j", JSON.stringify(sessionStorage));
+            await injectStorage(page, sessionStorage, SESSION_STORAGE);
+        }
+        if (localStorage) {
+            phantomas.log("Injecting localStorag: %j", JSON.stringify(localStorage));
+            await injectStorage(page, localStorage, LOCAL_STORAGE);
+        }
+    });
+
+    /**
+     * Inject the given storage into the specified page storage.
+     * Either localStorage or sessionStorage
+     * 
+     * @param {Page} page in which page the storage should be injected
+     * @param {Object} storage the JSON object consisting of the storage keys and values
+     * @param {string} storageType either localStorage or sessionStorage
+     */
+    async function injectStorage(page, storage, storageType) {
+        if (!page || !storage || !storageType) {
+            return;
+        }
+
+        await page.evaluateOnNewDocument((storage, storageType, SESSION_STORAGE, LOCAL_STORAGE) => {
+            const keys = Object.keys(storage);
+            const values = Object.values(storage);
+            if (storageType === SESSION_STORAGE) {
+                for (let i = 0; i < keys.length; i++) {
+                    sessionStorage.setItem(keys[i], values[i]);
+                }
+            }
+            if (storageType === LOCAL_STORAGE) {
+                for (let i = 0; i < keys.length; i++) {
+                    localStorage.setItem(keys[i], values[i]);
+                }
+            }
+        }, storage, storageType, SESSION_STORAGE, LOCAL_STORAGE);
+    }
+};

--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -578,6 +578,19 @@
     localStorageEntries: 2
   offenders:
     localStorageEntries: ["foo", "test"]
+
+# local/session storage injection
+- url: "/local-storage-injection.html"
+  options:
+    "local-storage": "bar=foo"
+  metrics:
+    local-storage: '{"bar":"foo"}'
+- url: "/session-storage-injection.html"
+  options:
+    "session-storage": "bar=foo"
+  metrics:
+    session-storage: '{"bar":"foo"}'
+    
 # JS errors
 - url: "/js-errors.html"
   metrics:

--- a/test/webroot/local-storage-injection.html
+++ b/test/webroot/local-storage-injection.html
@@ -1,0 +1,9 @@
+<body>
+	<script>
+		console.log('Got local-storage: ' + JSON.stringify(window.localStorage));
+		// for unit tests
+		(function(phantomas) {
+			phantomas.setMetric('local-storage', JSON.stringify(window.localStorage));
+		})(window.__phantomas);
+	</script>
+</body>

--- a/test/webroot/session-storage-injection.html
+++ b/test/webroot/session-storage-injection.html
@@ -1,0 +1,9 @@
+<body>
+	<script>
+		console.log('Got session-storage: ' + JSON.stringify(sessionStorage));
+		// for unit tests
+		(function(phantomas) {
+			phantomas.setMetric('session-storage', JSON.stringify(sessionStorage));
+		})(window.__phantomas);
+	</script>
+</body>


### PR DESCRIPTION
Hello guys,
we have a little contribution for you and it would be great, if you could review the changes and hopefully bringing this in a future release ☺️ 

- For authentication purposes it could be useful, to have the ability to inject several session-/localStorage values into the page handled by puppeteer.

- This extension will use the phantomas parameter _sessionStorage_ and _localStorage_ and inject them into the page storage respectively.
