### PR TITLE
Dockerfile: chromium from the "edge" Alpine branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
 
 RUN echo "Chromium binary is in: $(which chromium-browser), its dependencies:"; \
   ldd $(which chromium-browser); \
-  chromium-browser --no-sandbox --version
+  chromium-browser --no-sandbox --disable-gpu --version
 
 # Set up a working directory
 ENV HOME /opt/phantomas

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,17 @@ FROM node:lts-alpine3.14
 # https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium
 ENV CHROMIUM_VERSION 96.0.4664.45-r0
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+RUN echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+  && echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
   && apk upgrade -U -a \
   && apk add \
-    chromium \
-    ca-certificates \
-    freetype \
-    freetype-dev \
-    harfbuzz \
-    nss \
-    ttf-freefont
+    chromium@edge \
+    ca-certificates@edge \
+    freetype@edge \
+    freetype-dev@edge \
+    harfbuzz@edge \
+    nss@edge \
+    ttf-freefont@edge
 
 RUN echo "Chromium binary is in: $(which chromium-browser), its dependencies:"; \
   ldd $(which chromium-browser); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
 
 RUN echo "Chromium binary is in: $(which chromium-browser), its dependencies:"; \
   ldd $(which chromium-browser); \
-  chromium-browser --no-sandbox --disable-gpu --version
+  chromium-browser --no-sandbox --disable-gpu --headless --version
 
 # Set up a working directory
 ENV HOME /opt/phantomas

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:lts-alpine3.14
 # https://pkgs.alpinelinux.org/package/edge/community/x86_64/chromium
 ENV CHROMIUM_VERSION 96.0.4664.45-r0
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.14/main" >> /etc/apk/repositories \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
   && apk upgrade -U -a \
   && apk add \
     chromium \


### PR DESCRIPTION
It's Chromium 96 (`edge`) vs 93 (`v3.14`).

----

```
#6 6.140 (117/123) Installing chromium@edge (96.0.4664.45-r0)
(...)
#7 0.486 Error relocating /usr/lib/chromium/chrome: _ZSt28__throw_bad_array_new_lengthv: symbol not found
#7 0.486 Error relocating /usr/lib/chromium/chrome: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEv: symbol not found
#7 0.487 Error relocating /usr/lib/chromium/chrome: _ZNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEE7reserveEv: symbol not found
```

> https://github.com/puppeteer/puppeteer/issues/3019