### PR TITLE
Introduce flaky tests handling

### DIFF
--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -655,6 +655,7 @@
 
 # not found
 - url: "/not-found.html"
+  flaky: Throws "Navigation failed because browser has disconnected!" randomly
   metrics:
     requests: 2
     notFound: 1

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -79,6 +79,14 @@ describe("Integration tests", () => {
       return;
     }
 
+    // do not run flaky tests
+    if (test.flaky) {
+      describe.skip(testCaseName, () => {
+        it(test.flaky, () => {});
+      });
+      return;
+    }
+
     describe(testCaseName, () => {
       let promise, results;
 


### PR DESCRIPTION
* [x] mark "/not-found.html" test as flaky - throws "Navigation failed because browser has disconnected!" randomly (see #1142)
* Coverage decreased (-0.1%) to 89.189%

```
Test Suites: 14 passed, 14 total
Tests:       2 skipped, 505 passed, 507 total
```