### PR TITLE
bump puppeteer to v15.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^15.1.1"
+        "puppeteer": "^15.2.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.1.1.tgz",
-      "integrity": "sha512-XMysu48uIcaYad/IelRTX3yxpHkcNdhdzPegnBEz9h1uEQfLhFcMJnjyvus51Sm+OPwr2gaKQhtyuIVaVKqd0Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.2.0.tgz",
+      "integrity": "sha512-6Mzj5pbq4J4DxJE5o6V+arrOB9Gma0CxOLP1zKYMrMR7AYuNaPzsK7pBrpDwI64W6Mxk5G7NqiLSFTrgSzR1zg==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7881,9 +7881,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.1.1.tgz",
-      "integrity": "sha512-XMysu48uIcaYad/IelRTX3yxpHkcNdhdzPegnBEz9h1uEQfLhFcMJnjyvus51Sm+OPwr2gaKQhtyuIVaVKqd0Q==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.2.0.tgz",
+      "integrity": "sha512-6Mzj5pbq4J4DxJE5o6V+arrOB9Gma0CxOLP1zKYMrMR7AYuNaPzsK7pBrpDwI64W6Mxk5G7NqiLSFTrgSzR1zg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^15.1.1"
+    "puppeteer": "^15.2.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v15.2.0).

Uses `HeadlessChrome/104.0.5109.0`