### PR TITLE
bump puppeteer to v15.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^15.4.0"
+        "puppeteer": "^15.4.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.0.tgz",
-      "integrity": "sha512-wxJRbofjaycCaQ9fhABlToJobrjxlABiFi6NvdkOPVJMYFblxDlDTjkg+b6bZYi7xN+lEXn84GBZsA5DYb3wfw==",
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.2.tgz",
+      "integrity": "sha512-RIxzCIU8aJWh3ruc63xcByRYHPYJsXn4VbrrPtVQfMFcfYOnBqUeJ0CstDVv/NEZGpwozIPZBNU6zqY4zIn7vg==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7881,9 +7881,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.0.tgz",
-      "integrity": "sha512-wxJRbofjaycCaQ9fhABlToJobrjxlABiFi6NvdkOPVJMYFblxDlDTjkg+b6bZYi7xN+lEXn84GBZsA5DYb3wfw==",
+      "version": "15.4.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.4.2.tgz",
+      "integrity": "sha512-RIxzCIU8aJWh3ruc63xcByRYHPYJsXn4VbrrPtVQfMFcfYOnBqUeJ0CstDVv/NEZGpwozIPZBNU6zqY4zIn7vg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^15.4.0"
+    "puppeteer": "^15.4.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v15.4.2) // `HeadlessChrome/104.0.5109.0`