### PR TITLE
bump puppeteer to v16.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^15.5.0"
+        "puppeteer": "^16.0.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.5.0.tgz",
-      "integrity": "sha512-+vZPU8iBSdCx1Kn5hHas80fyo0TiVyMeqLGv/1dygX2HKhAZjO9YThadbRTCoTYq0yWw+w/CysldPsEekDtjDQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.0.0.tgz",
+      "integrity": "sha512-FgSe21IHNHkqv1SiJiob4ANsxVujcINa4p3MaDEMyoZsocbgSgwYE0c9lnF8eoinw4id3vx4DOXwhFdOOwVlDg==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -4093,7 +4093,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.0"
+        "ws": "8.8.1"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -4783,9 +4783,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7881,9 +7881,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.5.0.tgz",
-      "integrity": "sha512-+vZPU8iBSdCx1Kn5hHas80fyo0TiVyMeqLGv/1dygX2HKhAZjO9YThadbRTCoTYq0yWw+w/CysldPsEekDtjDQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.0.0.tgz",
+      "integrity": "sha512-FgSe21IHNHkqv1SiJiob4ANsxVujcINa4p3MaDEMyoZsocbgSgwYE0c9lnF8eoinw4id3vx4DOXwhFdOOwVlDg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7896,7 +7896,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.0"
+        "ws": "8.8.1"
       }
     },
     "react-is": {
@@ -8420,9 +8420,9 @@
       }
     },
     "ws": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
-      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
+      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^15.5.0"
+    "puppeteer": "^16.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v16.0.0) `HeadlessChrome/105.0.5173.0`