### PR TITLE
bump puppeteer to v16.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^16.0.0"
+        "puppeteer": "^16.1.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.0.0.tgz",
-      "integrity": "sha512-FgSe21IHNHkqv1SiJiob4ANsxVujcINa4p3MaDEMyoZsocbgSgwYE0c9lnF8eoinw4id3vx4DOXwhFdOOwVlDg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.1.0.tgz",
+      "integrity": "sha512-lhykJLbH2bbBaP3NfYI2Vj0T4ctrdfVdEVf8glZITPnLfqrJ0nfUzAYuIz5YcA79k5lmFKANIhEXex+jQChU3g==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7881,9 +7881,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.0.0.tgz",
-      "integrity": "sha512-FgSe21IHNHkqv1SiJiob4ANsxVujcINa4p3MaDEMyoZsocbgSgwYE0c9lnF8eoinw4id3vx4DOXwhFdOOwVlDg==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.1.0.tgz",
+      "integrity": "sha512-lhykJLbH2bbBaP3NfYI2Vj0T4ctrdfVdEVf8glZITPnLfqrJ0nfUzAYuIz5YcA79k5lmFKANIhEXex+jQChU3g==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^16.0.0"
+    "puppeteer": "^16.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v16.1.0) // `HeadlessChrome/105.0.5173.0`