### PR TITLE
bump puppeteer to v17.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^16.2.0"
+        "puppeteer": "^17.0.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4084,9 +4084,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.2.0.tgz",
-      "integrity": "sha512-7Au6iC98rS6WEAD110V4Bxd0iIbqoFtzz9XzkG1BSofidS1VAJ881E1+GFR7Xn2Yea0hbj8n0ErzRyseMp1Ctg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
+      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7894,9 +7894,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-16.2.0.tgz",
-      "integrity": "sha512-7Au6iC98rS6WEAD110V4Bxd0iIbqoFtzz9XzkG1BSofidS1VAJ881E1+GFR7Xn2Yea0hbj8n0ErzRyseMp1Ctg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
+      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^16.2.0"
+    "puppeteer": "^17.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v17.0.0)