### PR TITLE
bump puppeteer to v17.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^17.0.0"
+        "puppeteer": "^17.1.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1884,9 +1884,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1019158",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
-      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ=="
+      "version": "0.0.1036444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
+      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -4084,14 +4084,14 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
-      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.0.tgz",
+      "integrity": "sha512-cPBHruFaUGNTekw0I8P6vBY4sV9gFyh3WjDDv0UzlwSSRQVSl+igcuPVqa7NKDjKccki9X1nVn6HalIqBoJz6g==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1019158",
+        "devtools-protocol": "0.0.1036444",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
@@ -6280,9 +6280,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1019158",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
-      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ=="
+      "version": "0.0.1036444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1036444.tgz",
+      "integrity": "sha512-0y4f/T8H9lsESV9kKP1HDUXgHxCdniFeJh6Erq+FbdOEvp/Ydp9t8kcAAM5gOd17pMrTDlFWntoHtzzeTUWKNw=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -7894,13 +7894,13 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
-      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.0.tgz",
+      "integrity": "sha512-cPBHruFaUGNTekw0I8P6vBY4sV9gFyh3WjDDv0UzlwSSRQVSl+igcuPVqa7NKDjKccki9X1nVn6HalIqBoJz6g==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1019158",
+        "devtools-protocol": "0.0.1036444",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^17.0.0"
+    "puppeteer": "^17.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v17.1.0)