### PR TITLE
bump puppeteer to v17.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^17.1.0"
+        "puppeteer": "^17.1.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4084,9 +4084,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.0.tgz",
-      "integrity": "sha512-cPBHruFaUGNTekw0I8P6vBY4sV9gFyh3WjDDv0UzlwSSRQVSl+igcuPVqa7NKDjKccki9X1nVn6HalIqBoJz6g==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.2.tgz",
+      "integrity": "sha512-xgFOxUl4hRjwQpODZSeJlE/rUzi8OmHtc3T4ir4CRYGzVmaTVHAl8VGpI0ooy752u2DFeMxvQdHmxNnLqPImIg==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7894,9 +7894,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.0.tgz",
-      "integrity": "sha512-cPBHruFaUGNTekw0I8P6vBY4sV9gFyh3WjDDv0UzlwSSRQVSl+igcuPVqa7NKDjKccki9X1nVn6HalIqBoJz6g==",
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.1.2.tgz",
+      "integrity": "sha512-xgFOxUl4hRjwQpODZSeJlE/rUzi8OmHtc3T4ir4CRYGzVmaTVHAl8VGpI0ooy752u2DFeMxvQdHmxNnLqPImIg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^17.1.0"
+    "puppeteer": "^17.1.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v17.1.2)