### PR TITLE
bump puppeteer to v18.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^18.0.2"
+        "puppeteer": "^18.0.3"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4084,9 +4084,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.2.tgz",
-      "integrity": "sha512-EdquaZg1n5IgZJzUc/EXDmtghJU6aCZJ/pl2onwL2g+cfG5HkxwSRVNKkDf76qTk3fMh1OUtqvAJMUJ+6HvYEg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.3.tgz",
+      "integrity": "sha512-IiW4Zz0xbphl1lQEAB7grPucbk/aM+GND4aJ7I8gOzOSp7Ika1bz35maox4FbELpPL8sqXsVQRNrXQnzBMiCzQ==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7894,9 +7894,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.2.tgz",
-      "integrity": "sha512-EdquaZg1n5IgZJzUc/EXDmtghJU6aCZJ/pl2onwL2g+cfG5HkxwSRVNKkDf76qTk3fMh1OUtqvAJMUJ+6HvYEg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.3.tgz",
+      "integrity": "sha512-IiW4Zz0xbphl1lQEAB7grPucbk/aM+GND4aJ7I8gOzOSp7Ika1bz35maox4FbELpPL8sqXsVQRNrXQnzBMiCzQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^18.0.2"
+    "puppeteer": "^18.0.3"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v18.0.3)