### PR TITLE
bump puppeteer to v18.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^18.0.3"
+        "puppeteer": "^18.0.4"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4084,9 +4084,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.3.tgz",
-      "integrity": "sha512-IiW4Zz0xbphl1lQEAB7grPucbk/aM+GND4aJ7I8gOzOSp7Ika1bz35maox4FbELpPL8sqXsVQRNrXQnzBMiCzQ==",
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.4.tgz",
+      "integrity": "sha512-42WMdCu2wJdrkWijox/ZWsgNdv3+H+9xhLmiIl7KZIvDwMJWGz28HMgG1Ey5J6xb8wcwzjF9uI1Iw4UNyXXf5A==",
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
@@ -7894,9 +7894,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "18.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.3.tgz",
-      "integrity": "sha512-IiW4Zz0xbphl1lQEAB7grPucbk/aM+GND4aJ7I8gOzOSp7Ika1bz35maox4FbELpPL8sqXsVQRNrXQnzBMiCzQ==",
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.0.4.tgz",
+      "integrity": "sha512-42WMdCu2wJdrkWijox/ZWsgNdv3+H+9xhLmiIl7KZIvDwMJWGz28HMgG1Ey5J6xb8wcwzjF9uI1Iw4UNyXXf5A==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^18.0.3"
+    "puppeteer": "^18.0.4"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v18.0.4)