### PR TITLE
bump puppeteer to v18.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^18.2.0"
+        "puppeteer": "^18.2.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4084,24 +4084,24 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.2.0.tgz",
-      "integrity": "sha512-auxgcjcM7p7+2t6ga6izrrtks7Z1fl7Qv4Gwb9tvH0U0dnBYgbq8GxOZ5mDgSolWgN6NmfG2bxdfOPzc0yOfDA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.2.1.tgz",
+      "integrity": "sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "18.2.0"
+        "puppeteer-core": "18.2.1"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-18.2.0.tgz",
-      "integrity": "sha512-5JLJt3At3zNh6rVNG7o7VOonH6HIsPSFeUD+X4bTvfU8Fh/2ihuhXtE6+vYi5hG7sL+m3yq8cpCsV1Jh47i3/Q==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-18.2.1.tgz",
+      "integrity": "sha512-MRtTAZfQTluz3U2oU/X2VqVWPcR1+94nbA2V6ZrSZRVEwLqZ8eclZ551qGFQD/vD2PYqHJwWOW/fpC721uznVw==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7907,20 +7907,20 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.2.0.tgz",
-      "integrity": "sha512-auxgcjcM7p7+2t6ga6izrrtks7Z1fl7Qv4Gwb9tvH0U0dnBYgbq8GxOZ5mDgSolWgN6NmfG2bxdfOPzc0yOfDA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.2.1.tgz",
+      "integrity": "sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==",
       "requires": {
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "18.2.0"
+        "puppeteer-core": "18.2.1"
       }
     },
     "puppeteer-core": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-18.2.0.tgz",
-      "integrity": "sha512-5JLJt3At3zNh6rVNG7o7VOonH6HIsPSFeUD+X4bTvfU8Fh/2ihuhXtE6+vYi5hG7sL+m3yq8cpCsV1Jh47i3/Q==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-18.2.1.tgz",
+      "integrity": "sha512-MRtTAZfQTluz3U2oU/X2VqVWPcR1+94nbA2V6ZrSZRVEwLqZ8eclZ551qGFQD/vD2PYqHJwWOW/fpC721uznVw==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^18.2.0"
+    "puppeteer": "^18.2.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v18.2.1)