### PR TITLE
bump puppeteer to v19.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.1.0"
+        "puppeteer": "^19.1.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4093,25 +4093,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.0.tgz",
-      "integrity": "sha512-UyJ5gz5JNjuFo6VJzIf+qDNjbSWGSoAMLuW990eErcrH6sZP85EbpLi6yG50euTMudxO/lsj4w1VNDNogHv6dA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.1.tgz",
+      "integrity": "sha512-nyIytOp1mYagiVeKkWODuMAGJoeQkcGNy7utkm2BN2d2r90n1ezO1tM4ld2V3vpP4u2kGk20obqv/Lj0Icd3KA==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "7.0.1",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.1.0"
+        "puppeteer-core": "19.1.1"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.1.0.tgz",
-      "integrity": "sha512-xIIJJuvqWbUwNzaB7l0TyChJYHdLvLhcHQiBLLKsMfvaQXnVa0Fzooq3Zb5bc01Q/b7XiP9pqDvUcYWSmzZQHA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.1.1.tgz",
+      "integrity": "sha512-jV26Ke0VFel4MoXLjqm50uAW2uwksTP6Md1tvtXqWqXM5FyboKI6E9YYJ1qEQilUAqlhgGq8xLN5+SL8bPz/kw==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7927,21 +7927,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.0.tgz",
-      "integrity": "sha512-UyJ5gz5JNjuFo6VJzIf+qDNjbSWGSoAMLuW990eErcrH6sZP85EbpLi6yG50euTMudxO/lsj4w1VNDNogHv6dA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.1.tgz",
+      "integrity": "sha512-nyIytOp1mYagiVeKkWODuMAGJoeQkcGNy7utkm2BN2d2r90n1ezO1tM4ld2V3vpP4u2kGk20obqv/Lj0Icd3KA==",
       "requires": {
         "cosmiconfig": "7.0.1",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.1.0"
+        "puppeteer-core": "19.1.1"
       }
     },
     "puppeteer-core": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.1.0.tgz",
-      "integrity": "sha512-xIIJJuvqWbUwNzaB7l0TyChJYHdLvLhcHQiBLLKsMfvaQXnVa0Fzooq3Zb5bc01Q/b7XiP9pqDvUcYWSmzZQHA==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.1.1.tgz",
+      "integrity": "sha512-jV26Ke0VFel4MoXLjqm50uAW2uwksTP6Md1tvtXqWqXM5FyboKI6E9YYJ1qEQilUAqlhgGq8xLN5+SL8bPz/kw==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.1.0"
+    "puppeteer": "^19.1.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.1.1)