### PR TITLE
bump puppeteer to v19.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.1.1"
+        "puppeteer": "^19.1.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4093,12 +4093,13 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.1.tgz",
-      "integrity": "sha512-nyIytOp1mYagiVeKkWODuMAGJoeQkcGNy7utkm2BN2d2r90n1ezO1tM4ld2V3vpP4u2kGk20obqv/Lj0Icd3KA==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.2.tgz",
+      "integrity": "sha512-paX23NEpQRoJzz6g/q6A8PwSeAoa+WM263IFQL/ArJcyfotF1WvCBiZkzEcGD864Xm2rFvFuopBWYQjSBfeaQw==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "7.0.1",
+        "devtools-protocol": "0.0.1056733",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
@@ -4127,6 +4128,11 @@
       "engines": {
         "node": ">=14.1.0"
       }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1056733",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1056733.tgz",
+      "integrity": "sha512-CmTu6SQx2g3TbZzDCAV58+LTxVdKplS7xip0g5oDXpZ+isr0rv5dDP8ToyVRywzPHkCCPKgKgScEcwz4uPWDIA=="
     },
     "node_modules/react-is": {
       "version": "18.0.0",
@@ -7927,15 +7933,23 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.1.tgz",
-      "integrity": "sha512-nyIytOp1mYagiVeKkWODuMAGJoeQkcGNy7utkm2BN2d2r90n1ezO1tM4ld2V3vpP4u2kGk20obqv/Lj0Icd3KA==",
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.1.2.tgz",
+      "integrity": "sha512-paX23NEpQRoJzz6g/q6A8PwSeAoa+WM263IFQL/ArJcyfotF1WvCBiZkzEcGD864Xm2rFvFuopBWYQjSBfeaQw==",
       "requires": {
         "cosmiconfig": "7.0.1",
+        "devtools-protocol": "0.0.1056733",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "puppeteer-core": "19.1.1"
+      },
+      "dependencies": {
+        "devtools-protocol": {
+          "version": "0.0.1056733",
+          "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1056733.tgz",
+          "integrity": "sha512-CmTu6SQx2g3TbZzDCAV58+LTxVdKplS7xip0g5oDXpZ+isr0rv5dDP8ToyVRywzPHkCCPKgKgScEcwz4uPWDIA=="
+        }
       }
     },
     "puppeteer-core": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.1.1"
+    "puppeteer": "^19.1.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.1.2)