### PR TITLE
bump puppeteer to v19.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.2.1"
+        "puppeteer": "^19.2.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4093,9 +4093,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.1.tgz",
-      "integrity": "sha512-LwChdWDriDdegEZC36+kZRqq+ApI3zGni5dJrx3LVbt1+2AO4LPeYNI1MDz8MsrxB74IaV8/5eGtKLxOCg/wLw==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.2.tgz",
+      "integrity": "sha512-m1T5Mog5qu5+dMBptWYTn6pXRdnFbydbVUCthqwbfd8/kOiMlzZBR9ywjX79LpvI1Sj+/z8+FKeIsjnMul8ZYA==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "7.0.1",
@@ -4103,16 +4103,16 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.2.1"
+        "puppeteer-core": "19.2.2"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.1.tgz",
-      "integrity": "sha512-8T60tsWqk0z1yfptP6STFy/RH5hMLe3AVl4ZaU6/eoTrMV8+AdLGCSJA3wQG6Cu9d72DzGjHrJn4+3nRTguVmA==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.2.tgz",
+      "integrity": "sha512-faojf+1pZ/tHXSr4x1q+9MVd9FrL3rpdbC0w7qN7MNClMoLuCvMbpR4vzcjoiJYgclt1n+SOPUOmHQViTw6frw==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7928,22 +7928,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.1.tgz",
-      "integrity": "sha512-LwChdWDriDdegEZC36+kZRqq+ApI3zGni5dJrx3LVbt1+2AO4LPeYNI1MDz8MsrxB74IaV8/5eGtKLxOCg/wLw==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.2.tgz",
+      "integrity": "sha512-m1T5Mog5qu5+dMBptWYTn6pXRdnFbydbVUCthqwbfd8/kOiMlzZBR9ywjX79LpvI1Sj+/z8+FKeIsjnMul8ZYA==",
       "requires": {
         "cosmiconfig": "7.0.1",
         "devtools-protocol": "0.0.1056733",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.2.1"
+        "puppeteer-core": "19.2.2"
       }
     },
     "puppeteer-core": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.1.tgz",
-      "integrity": "sha512-8T60tsWqk0z1yfptP6STFy/RH5hMLe3AVl4ZaU6/eoTrMV8+AdLGCSJA3wQG6Cu9d72DzGjHrJn4+3nRTguVmA==",
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.2.tgz",
+      "integrity": "sha512-faojf+1pZ/tHXSr4x1q+9MVd9FrL3rpdbC0w7qN7MNClMoLuCvMbpR4vzcjoiJYgclt1n+SOPUOmHQViTw6frw==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.2.1"
+    "puppeteer": "^19.2.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.2.2)