### PR TITLE
bump puppeteer to v19.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.2.2"
+        "puppeteer": "^19.3.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4093,9 +4093,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.2.tgz",
-      "integrity": "sha512-m1T5Mog5qu5+dMBptWYTn6pXRdnFbydbVUCthqwbfd8/kOiMlzZBR9ywjX79LpvI1Sj+/z8+FKeIsjnMul8ZYA==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.3.0.tgz",
+      "integrity": "sha512-WJbi/ULaeuFOz7cfMgJlJCBAZiyqIFeQ6os4h5ex3PVTt2qosXgwI9eruFZqFAwJRv8x5pOuMhWR0aSRgyDqEg==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "7.0.1",
@@ -4103,16 +4103,16 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.2.2"
+        "puppeteer-core": "19.3.0"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.2.tgz",
-      "integrity": "sha512-faojf+1pZ/tHXSr4x1q+9MVd9FrL3rpdbC0w7qN7MNClMoLuCvMbpR4vzcjoiJYgclt1n+SOPUOmHQViTw6frw==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.3.0.tgz",
+      "integrity": "sha512-P8VAAOBnBJo/7DKJnj1b0K9kZBF2D8lkdL94CjJ+DZKCp182LQqYemPI9omUSZkh4bgykzXjZhaVR1qtddTTQg==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7928,22 +7928,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.2.2.tgz",
-      "integrity": "sha512-m1T5Mog5qu5+dMBptWYTn6pXRdnFbydbVUCthqwbfd8/kOiMlzZBR9ywjX79LpvI1Sj+/z8+FKeIsjnMul8ZYA==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.3.0.tgz",
+      "integrity": "sha512-WJbi/ULaeuFOz7cfMgJlJCBAZiyqIFeQ6os4h5ex3PVTt2qosXgwI9eruFZqFAwJRv8x5pOuMhWR0aSRgyDqEg==",
       "requires": {
         "cosmiconfig": "7.0.1",
         "devtools-protocol": "0.0.1056733",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.2.2"
+        "puppeteer-core": "19.3.0"
       }
     },
     "puppeteer-core": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.2.2.tgz",
-      "integrity": "sha512-faojf+1pZ/tHXSr4x1q+9MVd9FrL3rpdbC0w7qN7MNClMoLuCvMbpR4vzcjoiJYgclt1n+SOPUOmHQViTw6frw==",
+      "version": "19.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.3.0.tgz",
+      "integrity": "sha512-P8VAAOBnBJo/7DKJnj1b0K9kZBF2D8lkdL94CjJ+DZKCp182LQqYemPI9omUSZkh4bgykzXjZhaVR1qtddTTQg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.2.2"
+    "puppeteer": "^19.3.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.3.0)