### PR TITLE
bump puppeteer to v19.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.4.0"
+        "puppeteer": "^19.4.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4087,26 +4087,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.0.tgz",
-      "integrity": "sha512-sRzWEfFSZCCcFUJflGtYI2V7A6qK4Jht+2JiI2LZgn+Nv/LOZZsBDEaGl98ZrS8oEcUA5on4p2yJbE0nzHNzIg==",
+      "version": "19.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.1.tgz",
+      "integrity": "sha512-PCnrR13B8A+VSEDXRmrNXRZbrkF1tfsI1hKSC7vs13eNS6CUD3Y4FA8SF8/VZy+Pm1kg5AggJT2Nu3HLAtGkFg==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
-        "devtools-protocol": "0.0.1068969",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.4.0"
+        "puppeteer-core": "19.4.1"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.0.tgz",
-      "integrity": "sha512-gG/jxseleZStinBn86x8r7trjcE4jcjx1hIQWOpACQhquHYMuKnrWxkzg+EDn8sN3wUtF/Ry9mtJgjM49oUOFQ==",
+      "version": "19.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.1.tgz",
+      "integrity": "sha512-JHIuqtqrUAx4jGOTxXu4ilapV2jabxtVMA/e4wwFUMvtSsqK4nVBSI+Z1SKDoz7gRy/JUIc8WzmfocCa6SIZ1w==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -4117,7 +4116,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.10.0"
+        "ws": "8.11.0"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -4806,9 +4805,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7908,22 +7907,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.0.tgz",
-      "integrity": "sha512-sRzWEfFSZCCcFUJflGtYI2V7A6qK4Jht+2JiI2LZgn+Nv/LOZZsBDEaGl98ZrS8oEcUA5on4p2yJbE0nzHNzIg==",
+      "version": "19.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.1.tgz",
+      "integrity": "sha512-PCnrR13B8A+VSEDXRmrNXRZbrkF1tfsI1hKSC7vs13eNS6CUD3Y4FA8SF8/VZy+Pm1kg5AggJT2Nu3HLAtGkFg==",
       "requires": {
         "cosmiconfig": "8.0.0",
-        "devtools-protocol": "0.0.1068969",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.4.0"
+        "puppeteer-core": "19.4.1"
       }
     },
     "puppeteer-core": {
-      "version": "19.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.0.tgz",
-      "integrity": "sha512-gG/jxseleZStinBn86x8r7trjcE4jcjx1hIQWOpACQhquHYMuKnrWxkzg+EDn8sN3wUtF/Ry9mtJgjM49oUOFQ==",
+      "version": "19.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.1.tgz",
+      "integrity": "sha512-JHIuqtqrUAx4jGOTxXu4ilapV2jabxtVMA/e4wwFUMvtSsqK4nVBSI+Z1SKDoz7gRy/JUIc8WzmfocCa6SIZ1w==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7934,7 +7932,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.10.0"
+        "ws": "8.11.0"
       }
     },
     "react-is": {
@@ -8457,9 +8455,9 @@
       }
     },
     "ws": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.4.0"
+    "puppeteer": "^19.4.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.4.1)