### PR TITLE
bump puppeteer to v19.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.4.1"
+        "puppeteer": "^19.5.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4087,25 +4087,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.1.tgz",
-      "integrity": "sha512-PCnrR13B8A+VSEDXRmrNXRZbrkF1tfsI1hKSC7vs13eNS6CUD3Y4FA8SF8/VZy+Pm1kg5AggJT2Nu3HLAtGkFg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
+      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.4.1"
+        "puppeteer-core": "19.5.0"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.1.tgz",
-      "integrity": "sha512-JHIuqtqrUAx4jGOTxXu4ilapV2jabxtVMA/e4wwFUMvtSsqK4nVBSI+Z1SKDoz7gRy/JUIc8WzmfocCa6SIZ1w==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
+      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7907,21 +7907,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.4.1.tgz",
-      "integrity": "sha512-PCnrR13B8A+VSEDXRmrNXRZbrkF1tfsI1hKSC7vs13eNS6CUD3Y4FA8SF8/VZy+Pm1kg5AggJT2Nu3HLAtGkFg==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
+      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
       "requires": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.4.1"
+        "puppeteer-core": "19.5.0"
       }
     },
     "puppeteer-core": {
-      "version": "19.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.4.1.tgz",
-      "integrity": "sha512-JHIuqtqrUAx4jGOTxXu4ilapV2jabxtVMA/e4wwFUMvtSsqK4nVBSI+Z1SKDoz7gRy/JUIc8WzmfocCa6SIZ1w==",
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
+      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.4.1"
+    "puppeteer": "^19.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.5.0)