### PR TITLE
bump puppeteer to v19.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.5.0"
+        "puppeteer": "^19.5.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4087,25 +4087,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
-      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
+      "version": "19.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.1.tgz",
+      "integrity": "sha512-8097xQkzbeA7jw4ubXvz7R5Lmt5Tpj9RzbetP/W1BGiHoIwgoniFwl6gpoWtGsLfI8m69YCLnxzWCW5XBMtz1g==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.5.0"
+        "puppeteer-core": "19.5.1"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
-      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
+      "version": "19.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.1.tgz",
+      "integrity": "sha512-+ai/wdeAulICv1a7Gs3W+WKb+CCqsNRM1n5IdR3w+KVGg/wcqE9VPgp6fXsjA16XAA+4kWofYxN6xLl1S0OKpg==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7907,21 +7907,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
-      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
+      "version": "19.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.1.tgz",
+      "integrity": "sha512-8097xQkzbeA7jw4ubXvz7R5Lmt5Tpj9RzbetP/W1BGiHoIwgoniFwl6gpoWtGsLfI8m69YCLnxzWCW5XBMtz1g==",
       "requires": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.5.0"
+        "puppeteer-core": "19.5.1"
       }
     },
     "puppeteer-core": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
-      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
+      "version": "19.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.1.tgz",
+      "integrity": "sha512-+ai/wdeAulICv1a7Gs3W+WKb+CCqsNRM1n5IdR3w+KVGg/wcqE9VPgp6fXsjA16XAA+4kWofYxN6xLl1S0OKpg==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.5.0"
+    "puppeteer": "^19.5.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.5.1)