### PR TITLE
bump puppeteer to v19.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.5.0"
+        "puppeteer": "^19.6.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1888,9 +1888,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1068969",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1068969.tgz",
-      "integrity": "sha512-ATFTrPbY1dKYhPPvpjtwWKSK2mIwGmRwX54UASn9THEuIZCe2n9k3vVuMmt6jWeL+e5QaaguEv/pMyR+JQB7VQ=="
+      "version": "0.0.1082910",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
+      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -4087,29 +4087,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
-      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.0.tgz",
+      "integrity": "sha512-KpRjn/bosTWe8xOQ/F5J1UmQ4inR77ADddn8G6MqMPp/y9Tl+7EycXgrjO0/3i/OQfHi5bsvkTKXRkm0ieo/ew==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.5.0"
+        "puppeteer-core": "19.6.0"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
-      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.0.tgz",
+      "integrity": "sha512-GvqWdHr9eY/MFR5pXf9o0apnrTmG0hhS7/TtCPfeAvCbaUS1bsLMZWxNGvI/QbviRu4xxi6HrR7VW4x/4esq1Q==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1068969",
+        "devtools-protocol": "0.0.1082910",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
@@ -6297,9 +6297,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1068969",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1068969.tgz",
-      "integrity": "sha512-ATFTrPbY1dKYhPPvpjtwWKSK2mIwGmRwX54UASn9THEuIZCe2n9k3vVuMmt6jWeL+e5QaaguEv/pMyR+JQB7VQ=="
+      "version": "0.0.1082910",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
+      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -7907,25 +7907,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.5.0.tgz",
-      "integrity": "sha512-601tKJdKu/mlL6l5wklNJiQbIxyEU2N4pwZzFkwhr1VizNYV0Fly1aFMT7qAp7CvzklYLypQGKn7/Zgpy+HheA==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.0.tgz",
+      "integrity": "sha512-KpRjn/bosTWe8xOQ/F5J1UmQ4inR77ADddn8G6MqMPp/y9Tl+7EycXgrjO0/3i/OQfHi5bsvkTKXRkm0ieo/ew==",
       "requires": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.5.0"
+        "puppeteer-core": "19.6.0"
       }
     },
     "puppeteer-core": {
-      "version": "19.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.5.0.tgz",
-      "integrity": "sha512-s2EE2x/7UfvR4AP+6OokY7yEmIboZoQFc2InuWUu5grWG7uka3W2Nch6+R4ERQepH4NO8kkkEBzNO4PqtwU4lQ==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.0.tgz",
+      "integrity": "sha512-GvqWdHr9eY/MFR5pXf9o0apnrTmG0hhS7/TtCPfeAvCbaUS1bsLMZWxNGvI/QbviRu4xxi6HrR7VW4x/4esq1Q==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1068969",
+        "devtools-protocol": "0.0.1082910",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.5.0"
+    "puppeteer": "^19.6.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.6.0)