### PR TITLE
bump puppeteer to v19.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.6.1"
+        "puppeteer": "^19.6.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4087,25 +4087,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.6.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.1.tgz",
-      "integrity": "sha512-gcqNilThyBPrUMvo2UZNG4KVoMjhCfCV7/84mTVk3oo0k65iO7hEKrB4waiJ15O0MHQpM79+XBHavRgBbRXUWQ==",
+      "version": "19.6.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.2.tgz",
+      "integrity": "sha512-Y5OAXXwXLfJYbl0dEFg8JKIhvCGxn+UYaBW9yra9ErmIhkVroDnYusM6oYxJCt/YIfC2pQWhvhxoZyf/E5fV6w==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.1"
+        "puppeteer-core": "19.6.2"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.6.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.1.tgz",
-      "integrity": "sha512-TdbqPYGHRgaqO1XPOM5ThE7uSs5NsYraOUU546okJz7jR9He5wnGuFd6LppoeWt8a4eM5RgzmICxeDUD5QwQtA==",
+      "version": "19.6.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.2.tgz",
+      "integrity": "sha512-il7uK658MNC1FlxPABvcnv1RdpDa9CaBFHzvtEsl+9Y4tbAJKZurkegpcvWeIWcRYGiuBIVo+t+ZSh3G82CCjw==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -7907,21 +7907,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.6.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.1.tgz",
-      "integrity": "sha512-gcqNilThyBPrUMvo2UZNG4KVoMjhCfCV7/84mTVk3oo0k65iO7hEKrB4waiJ15O0MHQpM79+XBHavRgBbRXUWQ==",
+      "version": "19.6.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.2.tgz",
+      "integrity": "sha512-Y5OAXXwXLfJYbl0dEFg8JKIhvCGxn+UYaBW9yra9ErmIhkVroDnYusM6oYxJCt/YIfC2pQWhvhxoZyf/E5fV6w==",
       "requires": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.1"
+        "puppeteer-core": "19.6.2"
       }
     },
     "puppeteer-core": {
-      "version": "19.6.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.1.tgz",
-      "integrity": "sha512-TdbqPYGHRgaqO1XPOM5ThE7uSs5NsYraOUU546okJz7jR9He5wnGuFd6LppoeWt8a4eM5RgzmICxeDUD5QwQtA==",
+      "version": "19.6.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.2.tgz",
+      "integrity": "sha512-il7uK658MNC1FlxPABvcnv1RdpDa9CaBFHzvtEsl+9Y4tbAJKZurkegpcvWeIWcRYGiuBIVo+t+ZSh3G82CCjw==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.6.1"
+    "puppeteer": "^19.6.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.6.2)