### PR TITLE
bump puppeteer to v19.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.6.3"
+        "puppeteer": "^19.7.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1888,9 +1888,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -4087,29 +4087,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.3.tgz",
-      "integrity": "sha512-K03xTtGDwS6cBXX/EoqoZxglCUKcX2SLIl92fMnGMRjYpPGXoAV2yKEh3QXmXzKqfZXd8TxjjFww+tEttWv8kw==",
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.7.1.tgz",
+      "integrity": "sha512-Hampj7jHlicySL1sSLHCwoFoRCi6RcEbnZmRE5brtbk0mp6Td33+9kWQD2eFs09772JIt00ybPKr50Gt7Y18Xg==",
       "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.3"
+        "puppeteer-core": "19.7.1"
       },
       "engines": {
         "node": ">=14.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-      "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.7.1.tgz",
+      "integrity": "sha512-4b5Go25IA+0xrUIw0Qtqi4nxc0qwdu/C7VT1+tFPl1W27207YT+7bxfANC3PjXMlS6bcbzinCf5YfGqMl8tfyQ==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
@@ -4120,6 +4120,18 @@
       },
       "engines": {
         "node": ">=14.1.0"
+      },
+      "peerDependencies": {
+        "chromium-bidi": "0.4.3",
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "chromium-bidi": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -6297,9 +6309,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1082910",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
-      "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww=="
+      "version": "0.0.1094867",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1094867.tgz",
+      "integrity": "sha512-pmMDBKiRVjh0uKK6CT1WqZmM3hBVSgD+N2MrgyV1uNizAZMw4tx6i/RTc+/uCsKSCmg0xXx7arCP/OFcIwTsiQ=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -7907,25 +7919,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.6.3.tgz",
-      "integrity": "sha512-K03xTtGDwS6cBXX/EoqoZxglCUKcX2SLIl92fMnGMRjYpPGXoAV2yKEh3QXmXzKqfZXd8TxjjFww+tEttWv8kw==",
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.7.1.tgz",
+      "integrity": "sha512-Hampj7jHlicySL1sSLHCwoFoRCi6RcEbnZmRE5brtbk0mp6Td33+9kWQD2eFs09772JIt00ybPKr50Gt7Y18Xg==",
       "requires": {
         "cosmiconfig": "8.0.0",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.6.3"
+        "puppeteer-core": "19.7.1"
       }
     },
     "puppeteer-core": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-      "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
+      "version": "19.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.7.1.tgz",
+      "integrity": "sha512-4b5Go25IA+0xrUIw0Qtqi4nxc0qwdu/C7VT1+tFPl1W27207YT+7bxfANC3PjXMlS6bcbzinCf5YfGqMl8tfyQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
+        "devtools-protocol": "0.0.1094867",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.6.3"
+    "puppeteer": "^19.7.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.7.1)