### PR TITLE
bump puppeteer to v19.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.8.3"
+        "puppeteer": "^19.8.5"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.2.tgz",
-      "integrity": "sha512-YAwrqy68PskkCDnSsv0afR8l8u90KhodcIFXCage5NLAoeWm0STGmtVugLBp2wc5PnhnCapCKkMjp9fYjvJl2g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.0.tgz",
+      "integrity": "sha512-3iB5pWn9Sr55PKKwqFWSWjLsTKCOEhKNI+uV3BZesgXuA3IhsX8I3hW0HI+3ksMIPkh2mVYzKSpvgq3oicjG2Q==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4129,24 +4129,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.8.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.3.tgz",
-      "integrity": "sha512-sKtt3aDRAcWuemeEtRaJqWKRlQ72OyKVcxX3Ur3KyFUEEzb2sEHpFc2mBlTMPmzOiNg5dB4dnxfelV9/xypJrA==",
+      "version": "19.8.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.5.tgz",
+      "integrity": "sha512-WSjouU7eux6cwBMEz4A7mDRVZWTQQTDXrb1R6AhKDdeEgpiBBkAzcAusPhILxiJOKj60rULZpWuCZ7HZIO6GTA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "0.3.2",
+        "@puppeteer/browsers": "0.4.0",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.3"
+        "puppeteer-core": "19.8.5"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.8.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.3.tgz",
-      "integrity": "sha512-+gPT43K3trUIr+7+tNjCg95vMgM9RkFIeeyck3SXUTBpGkrf6sxfWckncqY8MnzHfRcyapvztKNmqvJ+Ngukyg==",
+      "version": "19.8.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.5.tgz",
+      "integrity": "sha512-zoGhim/oBQbkND6h4Xz4X7l5DkWVH9wH7z0mVty5qa/c0P1Yad47t/npVtt2xS10BiQwzztWKx7Pa2nJ5yykdw==",
       "dependencies": {
+        "@puppeteer/browsers": "0.4.0",
         "chromium-bidi": "0.4.6",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -5668,9 +5669,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.3.2.tgz",
-      "integrity": "sha512-YAwrqy68PskkCDnSsv0afR8l8u90KhodcIFXCage5NLAoeWm0STGmtVugLBp2wc5PnhnCapCKkMjp9fYjvJl2g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.0.tgz",
+      "integrity": "sha512-3iB5pWn9Sr55PKKwqFWSWjLsTKCOEhKNI+uV3BZesgXuA3IhsX8I3hW0HI+3ksMIPkh2mVYzKSpvgq3oicjG2Q==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -7969,23 +7970,24 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.8.3",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.3.tgz",
-      "integrity": "sha512-sKtt3aDRAcWuemeEtRaJqWKRlQ72OyKVcxX3Ur3KyFUEEzb2sEHpFc2mBlTMPmzOiNg5dB4dnxfelV9/xypJrA==",
+      "version": "19.8.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.5.tgz",
+      "integrity": "sha512-WSjouU7eux6cwBMEz4A7mDRVZWTQQTDXrb1R6AhKDdeEgpiBBkAzcAusPhILxiJOKj60rULZpWuCZ7HZIO6GTA==",
       "requires": {
-        "@puppeteer/browsers": "0.3.2",
+        "@puppeteer/browsers": "0.4.0",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.3"
+        "puppeteer-core": "19.8.5"
       }
     },
     "puppeteer-core": {
-      "version": "19.8.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.3.tgz",
-      "integrity": "sha512-+gPT43K3trUIr+7+tNjCg95vMgM9RkFIeeyck3SXUTBpGkrf6sxfWckncqY8MnzHfRcyapvztKNmqvJ+Ngukyg==",
+      "version": "19.8.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.5.tgz",
+      "integrity": "sha512-zoGhim/oBQbkND6h4Xz4X7l5DkWVH9wH7z0mVty5qa/c0P1Yad47t/npVtt2xS10BiQwzztWKx7Pa2nJ5yykdw==",
       "requires": {
+        "@puppeteer/browsers": "0.4.0",
         "chromium-bidi": "0.4.6",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.8.3"
+    "puppeteer": "^19.8.5"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.8.5)