### PR TITLE
bump puppeteer to v19.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.8.5"
+        "puppeteer": "^19.9.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.0.tgz",
-      "integrity": "sha512-3iB5pWn9Sr55PKKwqFWSWjLsTKCOEhKNI+uV3BZesgXuA3IhsX8I3hW0HI+3ksMIPkh2mVYzKSpvgq3oicjG2Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.1.tgz",
+      "integrity": "sha512-4IICvy1McAkT/HyNZHIs7sp8ngBX1dmO0TPQ+FWq9ATQMqI8p+Ulm5A3kS2wYDh5HDHHkYrrETOu6rlj64VuTw==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4129,25 +4129,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.8.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.5.tgz",
-      "integrity": "sha512-WSjouU7eux6cwBMEz4A7mDRVZWTQQTDXrb1R6AhKDdeEgpiBBkAzcAusPhILxiJOKj60rULZpWuCZ7HZIO6GTA==",
+      "version": "19.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.9.0.tgz",
+      "integrity": "sha512-JDx8WwGlkdQYTaa3OMYDF+uFWimiwNnacg5FGEC5J6+VxDsLK30wHKU/Db2LqEhtAoIu4RwS+BRH4zRPlCsFpA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "0.4.0",
+        "@puppeteer/browsers": "0.4.1",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.5"
+        "puppeteer-core": "19.9.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.8.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.5.tgz",
-      "integrity": "sha512-zoGhim/oBQbkND6h4Xz4X7l5DkWVH9wH7z0mVty5qa/c0P1Yad47t/npVtt2xS10BiQwzztWKx7Pa2nJ5yykdw==",
+      "version": "19.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.9.0.tgz",
+      "integrity": "sha512-IJYfCE0oFpi5dTvNFqOwo8Dey6zzx7hANy7z6K2bjpCux9oPOSOIubq40awNhaHlfi8soYtgU4qabnzMXB7xBQ==",
       "dependencies": {
-        "@puppeteer/browsers": "0.4.0",
+        "@puppeteer/browsers": "0.4.1",
         "chromium-bidi": "0.4.6",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
@@ -5669,9 +5669,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.0.tgz",
-      "integrity": "sha512-3iB5pWn9Sr55PKKwqFWSWjLsTKCOEhKNI+uV3BZesgXuA3IhsX8I3hW0HI+3ksMIPkh2mVYzKSpvgq3oicjG2Q==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.4.1.tgz",
+      "integrity": "sha512-4IICvy1McAkT/HyNZHIs7sp8ngBX1dmO0TPQ+FWq9ATQMqI8p+Ulm5A3kS2wYDh5HDHHkYrrETOu6rlj64VuTw==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -7970,24 +7970,24 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.8.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.8.5.tgz",
-      "integrity": "sha512-WSjouU7eux6cwBMEz4A7mDRVZWTQQTDXrb1R6AhKDdeEgpiBBkAzcAusPhILxiJOKj60rULZpWuCZ7HZIO6GTA==",
+      "version": "19.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.9.0.tgz",
+      "integrity": "sha512-JDx8WwGlkdQYTaa3OMYDF+uFWimiwNnacg5FGEC5J6+VxDsLK30wHKU/Db2LqEhtAoIu4RwS+BRH4zRPlCsFpA==",
       "requires": {
-        "@puppeteer/browsers": "0.4.0",
+        "@puppeteer/browsers": "0.4.1",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.8.5"
+        "puppeteer-core": "19.9.0"
       }
     },
     "puppeteer-core": {
-      "version": "19.8.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.8.5.tgz",
-      "integrity": "sha512-zoGhim/oBQbkND6h4Xz4X7l5DkWVH9wH7z0mVty5qa/c0P1Yad47t/npVtt2xS10BiQwzztWKx7Pa2nJ5yykdw==",
+      "version": "19.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.9.0.tgz",
+      "integrity": "sha512-IJYfCE0oFpi5dTvNFqOwo8Dey6zzx7hANy7z6K2bjpCux9oPOSOIubq40awNhaHlfi8soYtgU4qabnzMXB7xBQ==",
       "requires": {
-        "@puppeteer/browsers": "0.4.0",
+        "@puppeteer/browsers": "0.4.1",
         "chromium-bidi": "0.4.6",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.8.5"
+    "puppeteer": "^19.9.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.9.0)