### PR TITLE
bump puppeteer to v19.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^19.9.1"
+        "puppeteer": "^19.10.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4129,9 +4129,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "19.9.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.9.1.tgz",
-      "integrity": "sha512-Ii8yZySNdpPzeKAK6ROFQ+gAi04igoZ0cPsBE1LW9fmzkqQTqbJpEGhJ/5gBS8oVqkQ2CNFA4BskJl75zaWWgA==",
+      "version": "19.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.10.0.tgz",
+      "integrity": "sha512-u2ftBcAu1cL5x2uKD5FLhHkN60Z1d5T0iMftiUEyRfdwT0poObRvjpc69F0HbtN/7lFeW2v+VN4pgeVVSOZYWg==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "0.4.1",
@@ -4139,13 +4139,13 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.9.1"
+        "puppeteer-core": "19.10.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "19.9.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.9.1.tgz",
-      "integrity": "sha512-46JGqhqTgYO5DuUMRGUiMCKM/86uHMsMCK7Fw7cbY/p+eCKLIPGVyQyI/E0UcGYa0+OH3dz0ResaDdHxqCgDDw==",
+      "version": "19.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.10.0.tgz",
+      "integrity": "sha512-F6btgaEJXcpdw/kJszBhe7t4kx1C42oG159romCagX8ttComuk5dqkmAd/AQc/E4cS3onOUsHI5WgjIstuYsFw==",
       "dependencies": {
         "@puppeteer/browsers": "0.4.1",
         "chromium-bidi": "0.4.6",
@@ -7970,22 +7970,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "19.9.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.9.1.tgz",
-      "integrity": "sha512-Ii8yZySNdpPzeKAK6ROFQ+gAi04igoZ0cPsBE1LW9fmzkqQTqbJpEGhJ/5gBS8oVqkQ2CNFA4BskJl75zaWWgA==",
+      "version": "19.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.10.0.tgz",
+      "integrity": "sha512-u2ftBcAu1cL5x2uKD5FLhHkN60Z1d5T0iMftiUEyRfdwT0poObRvjpc69F0HbtN/7lFeW2v+VN4pgeVVSOZYWg==",
       "requires": {
         "@puppeteer/browsers": "0.4.1",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "19.9.1"
+        "puppeteer-core": "19.10.0"
       }
     },
     "puppeteer-core": {
-      "version": "19.9.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.9.1.tgz",
-      "integrity": "sha512-46JGqhqTgYO5DuUMRGUiMCKM/86uHMsMCK7Fw7cbY/p+eCKLIPGVyQyI/E0UcGYa0+OH3dz0ResaDdHxqCgDDw==",
+      "version": "19.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.10.0.tgz",
+      "integrity": "sha512-F6btgaEJXcpdw/kJszBhe7t4kx1C42oG159romCagX8ttComuk5dqkmAd/AQc/E4cS3onOUsHI5WgjIstuYsFw==",
       "requires": {
         "@puppeteer/browsers": "0.4.1",
         "chromium-bidi": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^19.9.1"
+    "puppeteer": "^19.10.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v19.10.0)