### PR TITLE
bump puppeteer to v20.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantomas",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phantomas",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "analyze-css": "^2.0.0",
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^20.0.0"
+        "puppeteer": "^20.1.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1929,9 +1929,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1107588",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
+      "version": "0.0.1120988",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -4129,9 +4129,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.0.0.tgz",
-      "integrity": "sha512-oVqHsbZFbZzEkRoNR2dZKhUG5fHAQ+vWTRLJ6vrKY5+amsz3bRF3BCTqidbDa6TG+bZ5Y4P+FVv6SUNzxsTvLA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.0.tgz",
+      "integrity": "sha512-kZp1eYScK1IpHxkgnDaFSGKKCzt27iZfsxO6Xlv/cklzYrhobxTK9/PxzCacPCrYnxNQwKwHzHLPOCuSyjw1jg==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.0.0",
@@ -4139,19 +4139,19 @@
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "20.0.0"
+        "puppeteer-core": "20.1.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.0.0.tgz",
-      "integrity": "sha512-mQg1pXOqomTB0ecuv6WWrd+PxSeV4uC+wiUM+UYvENuKNq9m0fG9ZXhHLK1COwZH/A5IILzJH2sfQ0ivmxobGw==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.0.tgz",
+      "integrity": "sha512-/xTvabzAN4mnnuYkJCuWNnnEhOb3JrBTa3sY6qVi1wybuIEk5ODRg8Z5PPiKUGiKC9iG7GWOJ5CjF3iuMuxZSA==",
       "dependencies": {
         "@puppeteer/browsers": "1.0.0",
         "chromium-bidi": "0.4.7",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1107588",
+        "devtools-protocol": "0.0.1120988",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",
@@ -6359,9 +6359,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1107588",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-      "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg=="
+      "version": "0.0.1120988",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
+      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -7970,28 +7970,28 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.0.0.tgz",
-      "integrity": "sha512-oVqHsbZFbZzEkRoNR2dZKhUG5fHAQ+vWTRLJ6vrKY5+amsz3bRF3BCTqidbDa6TG+bZ5Y4P+FVv6SUNzxsTvLA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.0.tgz",
+      "integrity": "sha512-kZp1eYScK1IpHxkgnDaFSGKKCzt27iZfsxO6Xlv/cklzYrhobxTK9/PxzCacPCrYnxNQwKwHzHLPOCuSyjw1jg==",
       "requires": {
         "@puppeteer/browsers": "1.0.0",
         "cosmiconfig": "8.1.3",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "20.0.0"
+        "puppeteer-core": "20.1.0"
       }
     },
     "puppeteer-core": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.0.0.tgz",
-      "integrity": "sha512-mQg1pXOqomTB0ecuv6WWrd+PxSeV4uC+wiUM+UYvENuKNq9m0fG9ZXhHLK1COwZH/A5IILzJH2sfQ0ivmxobGw==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.0.tgz",
+      "integrity": "sha512-/xTvabzAN4mnnuYkJCuWNnnEhOb3JrBTa3sY6qVi1wybuIEk5ODRg8Z5PPiKUGiKC9iG7GWOJ5CjF3iuMuxZSA==",
       "requires": {
         "@puppeteer/browsers": "1.0.0",
         "chromium-bidi": "0.4.7",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1107588",
+        "devtools-protocol": "0.0.1120988",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "proxy-from-env": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^20.0.0"
+    "puppeteer": "^20.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v20.1.0)