### PR TITLE
bump puppeteer to v20.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^20.1.1"
+        "puppeteer": "^20.1.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.0.1.tgz",
-      "integrity": "sha512-9wkYhON9zBgtjYRE3FcokGCfjG25zjzNAYmsHpiWitRZ/4DeT3v125/fCUU66SaPJ4nUsxGNPgpS1TOcQ+8StA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.1.0.tgz",
+      "integrity": "sha512-+Nfk52G9cRAKq/V2LEaOlKIMsIuERSofk8hXEy6kMQtjg9Te1iuKymWOR+iKwwzj1RCkZU0fuOoSIclR839MNw==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4130,34 +4130,26 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.1.tgz",
-      "integrity": "sha512-agGDvDPIgYYwXL1WFP/O+HiDnFHJxtkmqyg4QOiHhgAgopyjOc+itL8SuXkJzXNSh9pnjGcZvl7ouJy/rU3SRg==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.2.tgz",
+      "integrity": "sha512-QYDp+iVMP30TwlkXFOocON9qR3Nac5ez7PdXbY90mfuEgZb9vf3/OXL2vHprxwPtb2hgD4AxXvLZhEIqfD2y8Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.0.1",
+        "@puppeteer/browsers": "1.1.0",
         "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "puppeteer-core": "20.1.1"
+        "puppeteer-core": "20.1.2"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.1.tgz",
-      "integrity": "sha512-iB9F2Om8J+nU4qi30oYw0hMWOw6eQN7kFkLLI/u3UvxONOCx5o0KmM6+byaK2/QGIuQu2ly1mPaJnC1DyoW07Q==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.2.tgz",
+      "integrity": "sha512-S1BLte+jVC/ugZkNoxFW9Fvbyr30CKZ0IIumf98FFqLh06Vuc21fddsr34botKtz27T81pqkpDYXNXYomA01dg==",
       "dependencies": {
-        "@puppeteer/browsers": "1.0.1",
+        "@puppeteer/browsers": "1.1.0",
         "chromium-bidi": "0.4.7",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1120988",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
         "ws": "8.13.0"
       },
       "engines": {
@@ -5670,9 +5662,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.0.1.tgz",
-      "integrity": "sha512-9wkYhON9zBgtjYRE3FcokGCfjG25zjzNAYmsHpiWitRZ/4DeT3v125/fCUU66SaPJ4nUsxGNPgpS1TOcQ+8StA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.1.0.tgz",
+      "integrity": "sha512-+Nfk52G9cRAKq/V2LEaOlKIMsIuERSofk8hXEy6kMQtjg9Te1iuKymWOR+iKwwzj1RCkZU0fuOoSIclR839MNw==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -7972,33 +7964,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.1.tgz",
-      "integrity": "sha512-agGDvDPIgYYwXL1WFP/O+HiDnFHJxtkmqyg4QOiHhgAgopyjOc+itL8SuXkJzXNSh9pnjGcZvl7ouJy/rU3SRg==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.1.2.tgz",
+      "integrity": "sha512-QYDp+iVMP30TwlkXFOocON9qR3Nac5ez7PdXbY90mfuEgZb9vf3/OXL2vHprxwPtb2hgD4AxXvLZhEIqfD2y8Q==",
       "requires": {
-        "@puppeteer/browsers": "1.0.1",
+        "@puppeteer/browsers": "1.1.0",
         "cosmiconfig": "8.1.3",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "puppeteer-core": "20.1.1"
+        "puppeteer-core": "20.1.2"
       }
     },
     "puppeteer-core": {
-      "version": "20.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.1.tgz",
-      "integrity": "sha512-iB9F2Om8J+nU4qi30oYw0hMWOw6eQN7kFkLLI/u3UvxONOCx5o0KmM6+byaK2/QGIuQu2ly1mPaJnC1DyoW07Q==",
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.1.2.tgz",
+      "integrity": "sha512-S1BLte+jVC/ugZkNoxFW9Fvbyr30CKZ0IIumf98FFqLh06Vuc21fddsr34botKtz27T81pqkpDYXNXYomA01dg==",
       "requires": {
-        "@puppeteer/browsers": "1.0.1",
+        "@puppeteer/browsers": "1.1.0",
         "chromium-bidi": "0.4.7",
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1120988",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
         "ws": "8.13.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^20.1.1"
+    "puppeteer": "^20.1.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v20.1.2)