### PR TITLE
bump puppeteer to v20.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "prettier": "2.7.1"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v20.5.0)