### PR TITLE
bump puppeteer to v20.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantomas",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phantomas",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "analyze-css": "^2.0.0",
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^20.5.0"
+        "puppeteer": "^20.6.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1954,9 +1954,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1120988",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
-      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
+      "version": "0.0.1135028",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1135028.tgz",
+      "integrity": "sha512-jEcNGrh6lOXNRJvZb9RjeevtZGrgugPKSMJZxfyxWQnhlKawMPhMtk/dfC+Z/6xNXExlzTKlY5LzIAK/fRpQIw=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -4408,26 +4408,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.5.0.tgz",
-      "integrity": "sha512-3j0JShJGDT5z8rfDKf+wZQq3IHxw7JaDAdP7py5H5zOIgmqNG0e8R19y4tFzJ8i2WC4H/0bC51rIrTXyDop1FA==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.6.0.tgz",
+      "integrity": "sha512-D/kkEIpDFRqpLOcCoNNdXI+IUcoD1FmdlWteT4FFPOhNLC46urmItMfQDKSwk2NJoO38ncgCQe5XEQ3QHD+piA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.4.1",
-        "cosmiconfig": "8.1.3",
-        "puppeteer-core": "20.5.0"
+        "cosmiconfig": "8.2.0",
+        "puppeteer-core": "20.6.0"
+      },
+      "engines": {
+        "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.5.0.tgz",
-      "integrity": "sha512-9ddHXUQ7jpliGei87zYTuEZYQvFj6Lzk5R8w4vT4gMmNArkEqC5CX72TnVIJiTUbiTpOXJkvMQaXIHYopjdUtQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.6.0.tgz",
+      "integrity": "sha512-vUE6VnqvOHX1ABssTxtzTJUzEJrTL49DmXflSvlRIcolzOISVni1niI5/oWsDxzyRVE9sfwe8QqFbsWozs5RPA==",
       "dependencies": {
         "@puppeteer/browsers": "1.4.1",
         "chromium-bidi": "0.4.11",
         "cross-fetch": "3.1.6",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1120988",
+        "devtools-protocol": "0.0.1135028",
         "ws": "8.13.0"
       },
       "engines": {
@@ -6617,9 +6620,9 @@
       }
     },
     "cosmiconfig": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
-      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "requires": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -6724,9 +6727,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1120988",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1120988.tgz",
-      "integrity": "sha512-39fCpE3Z78IaIPChJsP6Lhmkbf4dWXOmzLk/KFTdRkNk/0JymRIfUynDVRndV9HoDz8PyalK1UH21ST/ivwW5Q=="
+      "version": "0.0.1135028",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1135028.tgz",
+      "integrity": "sha512-jEcNGrh6lOXNRJvZb9RjeevtZGrgugPKSMJZxfyxWQnhlKawMPhMtk/dfC+Z/6xNXExlzTKlY5LzIAK/fRpQIw=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -8533,25 +8536,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.5.0.tgz",
-      "integrity": "sha512-3j0JShJGDT5z8rfDKf+wZQq3IHxw7JaDAdP7py5H5zOIgmqNG0e8R19y4tFzJ8i2WC4H/0bC51rIrTXyDop1FA==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.6.0.tgz",
+      "integrity": "sha512-D/kkEIpDFRqpLOcCoNNdXI+IUcoD1FmdlWteT4FFPOhNLC46urmItMfQDKSwk2NJoO38ncgCQe5XEQ3QHD+piA==",
       "requires": {
         "@puppeteer/browsers": "1.4.1",
-        "cosmiconfig": "8.1.3",
-        "puppeteer-core": "20.5.0"
+        "cosmiconfig": "8.2.0",
+        "puppeteer-core": "20.6.0"
       }
     },
     "puppeteer-core": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.5.0.tgz",
-      "integrity": "sha512-9ddHXUQ7jpliGei87zYTuEZYQvFj6Lzk5R8w4vT4gMmNArkEqC5CX72TnVIJiTUbiTpOXJkvMQaXIHYopjdUtQ==",
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.6.0.tgz",
+      "integrity": "sha512-vUE6VnqvOHX1ABssTxtzTJUzEJrTL49DmXflSvlRIcolzOISVni1niI5/oWsDxzyRVE9sfwe8QqFbsWozs5RPA==",
       "requires": {
         "@puppeteer/browsers": "1.4.1",
         "chromium-bidi": "0.4.11",
         "cross-fetch": "3.1.6",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1120988",
+        "devtools-protocol": "0.0.1135028",
         "ws": "8.13.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^20.5.0"
+    "puppeteer": "^20.6.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v20.6.0)