### PR TITLE
Fix a false JSError reported by Phantomas

### DIFF
--- a/modules/domQueries/scope.js
+++ b/modules/domQueries/scope.js
@@ -58,7 +58,7 @@
     var context = phantomas.getDOMPath(this);
 
     // querying by BODY and body is the same (issue #419)
-    tagName = tagName.toLowerCase();
+    if (tagName) tagName = tagName.toLowerCase();
 
     phantomas.incrMetric("DOMqueriesByTagName");
     phantomas.addOffender("DOMqueriesByTagName", {

--- a/test/webroot/js-errors.html
+++ b/test/webroot/js-errors.html
@@ -9,4 +9,11 @@
         // and this one too, but the execution will never reach this linen
         window.Foo('test');
 	</script>
+	<script>
+        // thoses ones should not fail (as in a real browser)
+        document.getElementsByTagName(undefined);
+        document.getElementById(undefined);
+        document.getElementsByClassName(undefined);
+        document.querySelector(undefined);
+	</script>
 </body>


### PR DESCRIPTION
Hi there!

I noticed that Phantomas was (rarely) reporting a JS error that doesn't exist in real browsers. 

If the `document.getElementsByTagName()` function is called with an incorrect value (such as `undefined` or `null`), browsers fail silently while Phantomas adds the following error to the JSErrors metric: `Cannot read properties of undefined (reading 'toLowerCase')`.

Here is a fix. No urgency in publishing that fix in a new version.