### PR TITLE
bump puppeteer to v20.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantomas",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phantomas",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "analyze-css": "^2.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v20.9.0)