### PR TITLE
bump puppeteer to v21.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.0.0"
+        "puppeteer": "^21.0.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -4333,23 +4333,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.0.tgz",
-      "integrity": "sha512-a3rpCJuKQ7mzlwMJzKX6GhvGeg4CUn4d9+dv+riQDpY4mns32Q9OnmkfTZ3VlbDhGyrdBf1xXF1Z4y0of00WYg==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.1.tgz",
+      "integrity": "sha512-KTjmSdPZ6bMkq3EbAzAUhcB3gMDXvdwd6912rxG9hNtjwRJzHSA568vh6vIbO2WQeNmozRdt1LtiUMLSWfeMrg==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.5.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.0"
+        "puppeteer-core": "21.0.1"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.0.tgz",
-      "integrity": "sha512-frnAOQ0pKrwxlYLziy+aB8q7cOm8Ym9Y5VqbdE7alOaOPIK3ynpYLi/1D6XJSKw3WExHmeI2z6TVO85SUxpVAQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.1.tgz",
+      "integrity": "sha512-E8eWLGhaZZpa7dYe/58qGX7SLb4mTg42NP5M7B+ibPrncgNjTOQa9x1sFIlTn1chF/BmoZqOcMIvwuxcb/9XzQ==",
       "dependencies": {
         "@puppeteer/browsers": "1.5.0",
         "chromium-bidi": "0.4.20",
@@ -4677,9 +4677,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -8351,19 +8351,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.0.tgz",
-      "integrity": "sha512-a3rpCJuKQ7mzlwMJzKX6GhvGeg4CUn4d9+dv+riQDpY4mns32Q9OnmkfTZ3VlbDhGyrdBf1xXF1Z4y0of00WYg==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.1.tgz",
+      "integrity": "sha512-KTjmSdPZ6bMkq3EbAzAUhcB3gMDXvdwd6912rxG9hNtjwRJzHSA568vh6vIbO2WQeNmozRdt1LtiUMLSWfeMrg==",
       "requires": {
         "@puppeteer/browsers": "1.5.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.0"
+        "puppeteer-core": "21.0.1"
       }
     },
     "puppeteer-core": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.0.tgz",
-      "integrity": "sha512-frnAOQ0pKrwxlYLziy+aB8q7cOm8Ym9Y5VqbdE7alOaOPIK3ynpYLi/1D6XJSKw3WExHmeI2z6TVO85SUxpVAQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.1.tgz",
+      "integrity": "sha512-E8eWLGhaZZpa7dYe/58qGX7SLb4mTg42NP5M7B+ibPrncgNjTOQa9x1sFIlTn1chF/BmoZqOcMIvwuxcb/9XzQ==",
       "requires": {
         "@puppeteer/browsers": "1.5.0",
         "chromium-bidi": "0.4.20",
@@ -8615,9 +8615,9 @@
       }
     },
     "streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
       "requires": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.0.0"
+    "puppeteer": "^21.0.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v21.0.1)