### PR TITLE
bump puppeteer to v21.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.0.0"
+        "puppeteer": "^21.0.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.0.tgz",
-      "integrity": "sha512-za318PweGINh5LnHSph7C4xhs0tmRjCD8EPpzcKlw4nzSPhnULj+LTG3+TGefZvW1ti5gjw2JkdQvQsivBeZlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
+      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4333,25 +4333,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.0.tgz",
-      "integrity": "sha512-a3rpCJuKQ7mzlwMJzKX6GhvGeg4CUn4d9+dv+riQDpY4mns32Q9OnmkfTZ3VlbDhGyrdBf1xXF1Z4y0of00WYg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
+      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.5.0",
+        "@puppeteer/browsers": "1.5.1",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.0"
+        "puppeteer-core": "21.0.2"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.0.tgz",
-      "integrity": "sha512-frnAOQ0pKrwxlYLziy+aB8q7cOm8Ym9Y5VqbdE7alOaOPIK3ynpYLi/1D6XJSKw3WExHmeI2z6TVO85SUxpVAQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
+      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
       "dependencies": {
-        "@puppeteer/browsers": "1.5.0",
+        "@puppeteer/browsers": "1.5.1",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
@@ -4677,9 +4677,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
       "dependencies": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"
@@ -5887,9 +5887,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.0.tgz",
-      "integrity": "sha512-za318PweGINh5LnHSph7C4xhs0tmRjCD8EPpzcKlw4nzSPhnULj+LTG3+TGefZvW1ti5gjw2JkdQvQsivBeZlg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
+      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -8351,21 +8351,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.0.tgz",
-      "integrity": "sha512-a3rpCJuKQ7mzlwMJzKX6GhvGeg4CUn4d9+dv+riQDpY4mns32Q9OnmkfTZ3VlbDhGyrdBf1xXF1Z4y0of00WYg==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
+      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
       "requires": {
-        "@puppeteer/browsers": "1.5.0",
+        "@puppeteer/browsers": "1.5.1",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.0"
+        "puppeteer-core": "21.0.2"
       }
     },
     "puppeteer-core": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.0.tgz",
-      "integrity": "sha512-frnAOQ0pKrwxlYLziy+aB8q7cOm8Ym9Y5VqbdE7alOaOPIK3ynpYLi/1D6XJSKw3WExHmeI2z6TVO85SUxpVAQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
+      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
       "requires": {
-        "@puppeteer/browsers": "1.5.0",
+        "@puppeteer/browsers": "1.5.1",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
@@ -8615,9 +8615,9 @@
       }
     },
     "streamx": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-      "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
+      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
       "requires": {
         "fast-fifo": "^1.1.0",
         "queue-tick": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.0.0"
+    "puppeteer": "^21.0.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v21.0.2)