### PR TITLE
bump puppeteer to v21.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.0.2"
+        "puppeteer": "^21.0.3"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
-      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.6.0.tgz",
+      "integrity": "sha512-R2ib8j329427jtKB/qlz0MJbwfJE/6I8ocJLiajsRqJ2PPI8DbjiNzC3lQZeISXEcjOBVhbG2RafN8SlHdcT+A==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -4333,25 +4333,25 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
-      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.3.tgz",
+      "integrity": "sha512-+eBNTEOOBrRBLJ1/jIuHcOoUUOVpUQjQFwp9L/sm/iBDqii+4jv9jxpPJSOmOHXuy++X7GWfhuDw4vz8crNzPw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.6.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.2"
+        "puppeteer-core": "21.0.3"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
-      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.3.tgz",
+      "integrity": "sha512-AGvopfkA0jLbW5Ba0m6kBuvRIpLo76PXUK3zJYkXOr9NI1LknJESyai6TtXc6GUSewMkinmyEDx1pFgq900hqg==",
       "dependencies": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.6.0",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
@@ -5887,9 +5887,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
-      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.6.0.tgz",
+      "integrity": "sha512-R2ib8j329427jtKB/qlz0MJbwfJE/6I8ocJLiajsRqJ2PPI8DbjiNzC3lQZeISXEcjOBVhbG2RafN8SlHdcT+A==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -8351,21 +8351,21 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
-      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.3.tgz",
+      "integrity": "sha512-+eBNTEOOBrRBLJ1/jIuHcOoUUOVpUQjQFwp9L/sm/iBDqii+4jv9jxpPJSOmOHXuy++X7GWfhuDw4vz8crNzPw==",
       "requires": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.6.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.2"
+        "puppeteer-core": "21.0.3"
       }
     },
     "puppeteer-core": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
-      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.3.tgz",
+      "integrity": "sha512-AGvopfkA0jLbW5Ba0m6kBuvRIpLo76PXUK3zJYkXOr9NI1LknJESyai6TtXc6GUSewMkinmyEDx1pFgq900hqg==",
       "requires": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.6.0",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.0.2"
+    "puppeteer": "^21.0.3"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v21.0.3)