### PR TITLE
bump puppeteer to v21.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.0.2"
+        "puppeteer": "^21.1.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -995,9 +995,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
-      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.7.0.tgz",
+      "integrity": "sha512-sl7zI0IkbQGak/+IE3VEEZab5SSOlI5F6558WvzWGC1n3+C722rfewC1ZIkcF9dsoGSsxhsONoseVlNQG4wWvQ==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -1934,9 +1934,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1147663",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
+      "version": "0.0.1159816",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1159816.tgz",
+      "integrity": "sha512-2cZlHxC5IlgkIWe2pSDmCrDiTzbSJWywjbDDnupOImEBcG31CQgBLV8wWE+5t+C4rimcjHsbzy7CBzf9oFjboA=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -2409,9 +2409,9 @@
       "dev": true
     },
     "node_modules/fast-fifo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
-      "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3887,9 +3887,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4333,29 +4333,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
-      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.1.0.tgz",
+      "integrity": "sha512-x0KfxVd7Hsefq8nzH1AAdSnYw5HEKI4QPeexBmx7nO29jDoEKNE+75G8zQ0E57ZOny/vAZZptCFdD3A7PkeESQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.7.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.2"
+        "puppeteer-core": "21.1.0"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
-      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.1.0.tgz",
+      "integrity": "sha512-ggfTj09jo81Y6M4DyNj80GrY6Pip+AtDUgGljqoSzP6FG5nz5Aju6Cs/X147fLgkJ4UKTb736U6cDp0ssLzN5Q==",
       "dependencies": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.7.0",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1147663",
+        "devtools-protocol": "0.0.1159816",
         "ws": "8.13.0"
       },
       "engines": {
@@ -4897,9 +4897,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5887,9 +5887,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.5.1.tgz",
-      "integrity": "sha512-OY8S5/DIsCSn/jahxw+qhCKa6jYQff6yq1oenzakISLvGcwWpyMzshJ3BIR7iP0vG0RPJjvHRLRxbsWw4kah1w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.7.0.tgz",
+      "integrity": "sha512-sl7zI0IkbQGak/+IE3VEEZab5SSOlI5F6558WvzWGC1n3+C722rfewC1ZIkcF9dsoGSsxhsONoseVlNQG4wWvQ==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -6584,9 +6584,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1147663",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
+      "version": "0.0.1159816",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1159816.tgz",
+      "integrity": "sha512-2cZlHxC5IlgkIWe2pSDmCrDiTzbSJWywjbDDnupOImEBcG31CQgBLV8wWE+5t+C4rimcjHsbzy7CBzf9oFjboA=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -6920,9 +6920,9 @@
       "dev": true
     },
     "fast-fifo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.0.tgz",
-      "integrity": "sha512-IgfweLvEpwyA4WgiQe9Nx6VV2QkML2NkvZnk1oKnIzXgXdWxuhF7zw4DvLTPZJn6PIUneiAXPF24QmoEqHTjyw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -8027,9 +8027,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -8351,25 +8351,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.0.2.tgz",
-      "integrity": "sha512-RAgbVjvwLABz8y+83xGdE+v7JLmvvcyGSlhQUX6k3rpBeRIO593E3DCaSY9VRUq3VJPMm7nWzDiZjUaK1tIpQg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.1.0.tgz",
+      "integrity": "sha512-x0KfxVd7Hsefq8nzH1AAdSnYw5HEKI4QPeexBmx7nO29jDoEKNE+75G8zQ0E57ZOny/vAZZptCFdD3A7PkeESQ==",
       "requires": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.7.0",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "21.0.2"
+        "puppeteer-core": "21.1.0"
       }
     },
     "puppeteer-core": {
-      "version": "21.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.0.2.tgz",
-      "integrity": "sha512-6tRjB9RZmPApPhQhzXZxmPUBt+6KM2P/eCp8p2o0DvK3P1V2qYkRi6/EQJEBIFquqZ+kF1zaW9Tg69p0dQlqFg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.1.0.tgz",
+      "integrity": "sha512-ggfTj09jo81Y6M4DyNj80GrY6Pip+AtDUgGljqoSzP6FG5nz5Aju6Cs/X147fLgkJ4UKTb736U6cDp0ssLzN5Q==",
       "requires": {
-        "@puppeteer/browsers": "1.5.1",
+        "@puppeteer/browsers": "1.7.0",
         "chromium-bidi": "0.4.20",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1147663",
+        "devtools-protocol": "0.0.1159816",
         "ws": "8.13.0"
       }
     },
@@ -8789,9 +8789,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.0.2"
+    "puppeteer": "^21.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/v21.1.0)