### PR TITLE
integration-spec.yaml: mark "httpbin's /basic-auth" as flaky

### DIFF
--- a/test/integration-spec.yaml
+++ b/test/integration-spec.yaml
@@ -816,6 +816,7 @@
 
 - url: "http://127.0.0.1:5555/basic-auth/foo/bar"
   label: "httpbin's /basic-auth (with --auth-user and --auth-pass)"
+  flaky: "http-bin sometimes gives us a single response"
   options:
     auth-user: "foo"
     auth-pass: "bar"


### PR DESCRIPTION
```
Integration tests › httpbin's /basic-auth (with --auth-user and --auth-pass) › should have "requests" metric set properly

    assert.strictEqual(received, expected)

    Expected value to strictly be equal to:
      2
    Received:
      1

      118 |       Object.keys(test.metrics || {}).forEach((name) => {
      119 |         it(`should have "${name}" metric set properly`, () => {
    > 120 |           assert.strictEqual(results.getMetric(name), test.metrics[name]);
          |                  ^
      121 |         });
      122 |       });
      123 |

      at Object.strictEqual (test/integration.test.js:120:18)
```