### PR TITLE
bump puppeteer to v21.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantomas",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phantomas",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "analyze-css": "^2.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.2.1)