### PR TITLE
bump puppeteer to v21.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.3.1"
+        "puppeteer": "^21.3.4"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -2452,9 +2452,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.27",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
-      "integrity": "sha512-8Irq0FbKYN8Xmj8M62kta6wk5MyDKeYIFtNavxQ2M3xf2v5MCC4ntf+FxitQu1iHaQvGU6t5O+Nrep0RNNS0EQ==",
+      "version": "0.4.28",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.28.tgz",
+      "integrity": "sha512-2HZ74QlAApJrEwcGlU/sUu0s4VS+FI3CJ09Toc9aE9VemMyhHZXeaROQgJKNRaYMUTUx6qIv1cLBs3F+vfgjSw==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -6673,30 +6673,30 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.1.tgz",
-      "integrity": "sha512-MhDvA+BYmzx+9vHJ/ZtknhlPbSPjTlHQnW1QYfkGpBcGW2Yy6eMahjkNuhAzN29H9tb47IcT0QsVcUy3Txx+SA==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.4.tgz",
+      "integrity": "sha512-kE67k1KR6hQs3g0Yf/i3GYOhTU8zC2dtcpHhtcSC9bGoVxRgqDo/hwVkDqlNKxJsJHuVX+qviWC7F0FdSjcFTA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.1"
+        "puppeteer-core": "21.3.4"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.1.tgz",
-      "integrity": "sha512-3VrCDEAHk0hPvE8qtfKgsT8CzRuaQrDQGXdCOuMFJM7Ap+ghpQzhPa9H3DE3gZgwDvC5Jt7SxUkAWLCeNbD0xw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.4.tgz",
+      "integrity": "sha512-iaG7ScTXOm9hlsBTBGGtr5dAAsA8IiWTx8E0Ghr0b5Ntl42bdcPS8EXjcERKocDhua2YqdlnFGs/cBxHY+VNyA==",
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.27",
+        "chromium-bidi": "0.4.28",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1179426",
-        "ws": "8.14.1"
+        "ws": "8.14.2"
       },
       "engines": {
         "node": ">=16.3.0"
@@ -7955,9 +7955,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
-      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9897,9 +9897,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.4.27",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.27.tgz",
-      "integrity": "sha512-8Irq0FbKYN8Xmj8M62kta6wk5MyDKeYIFtNavxQ2M3xf2v5MCC4ntf+FxitQu1iHaQvGU6t5O+Nrep0RNNS0EQ==",
+      "version": "0.4.28",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.28.tgz",
+      "integrity": "sha512-2HZ74QlAApJrEwcGlU/sUu0s4VS+FI3CJ09Toc9aE9VemMyhHZXeaROQgJKNRaYMUTUx6qIv1cLBs3F+vfgjSw==",
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -13024,26 +13024,26 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.1.tgz",
-      "integrity": "sha512-MhDvA+BYmzx+9vHJ/ZtknhlPbSPjTlHQnW1QYfkGpBcGW2Yy6eMahjkNuhAzN29H9tb47IcT0QsVcUy3Txx+SA==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.4.tgz",
+      "integrity": "sha512-kE67k1KR6hQs3g0Yf/i3GYOhTU8zC2dtcpHhtcSC9bGoVxRgqDo/hwVkDqlNKxJsJHuVX+qviWC7F0FdSjcFTA==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.1"
+        "puppeteer-core": "21.3.4"
       }
     },
     "puppeteer-core": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.1.tgz",
-      "integrity": "sha512-3VrCDEAHk0hPvE8qtfKgsT8CzRuaQrDQGXdCOuMFJM7Ap+ghpQzhPa9H3DE3gZgwDvC5Jt7SxUkAWLCeNbD0xw==",
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.4.tgz",
+      "integrity": "sha512-iaG7ScTXOm9hlsBTBGGtr5dAAsA8IiWTx8E0Ghr0b5Ntl42bdcPS8EXjcERKocDhua2YqdlnFGs/cBxHY+VNyA==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.27",
+        "chromium-bidi": "0.4.28",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1179426",
-        "ws": "8.14.1"
+        "ws": "8.14.2"
       }
     },
     "query-string": {
@@ -13953,9 +13953,9 @@
       }
     },
     "ws": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
-      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.3.1"
+    "puppeteer": "^21.3.4"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.3.4)