### PR TITLE
bump puppeteer to v21.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.3.4"
+        "puppeteer": "^21.3.5"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1237,9 +1237,9 @@
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
+      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -6673,23 +6673,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.4.tgz",
-      "integrity": "sha512-kE67k1KR6hQs3g0Yf/i3GYOhTU8zC2dtcpHhtcSC9bGoVxRgqDo/hwVkDqlNKxJsJHuVX+qviWC7F0FdSjcFTA==",
+      "version": "21.3.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.5.tgz",
+      "integrity": "sha512-Lff7dgN7D1AHnPBgceZiZpcXVpKOcnSCtBy+TZlwqYBumGapOky3/rUPScd6I6poh5XpPNzya6gbipBasAs7xA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.4"
+        "puppeteer-core": "21.3.5"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.4.tgz",
-      "integrity": "sha512-iaG7ScTXOm9hlsBTBGGtr5dAAsA8IiWTx8E0Ghr0b5Ntl42bdcPS8EXjcERKocDhua2YqdlnFGs/cBxHY+VNyA==",
+      "version": "21.3.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.5.tgz",
+      "integrity": "sha512-C/yVgvob/HbUVTedhnURDruFkJYHEqJWlb6YltJGj/T7yzWdG4ouQ0JER8aX5g2RS4DMQ0xMNuhUVYMqC2QfnQ==",
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "chromium-bidi": "0.4.28",
@@ -8993,9 +8993,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
+      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -13024,19 +13024,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.4.tgz",
-      "integrity": "sha512-kE67k1KR6hQs3g0Yf/i3GYOhTU8zC2dtcpHhtcSC9bGoVxRgqDo/hwVkDqlNKxJsJHuVX+qviWC7F0FdSjcFTA==",
+      "version": "21.3.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.5.tgz",
+      "integrity": "sha512-Lff7dgN7D1AHnPBgceZiZpcXVpKOcnSCtBy+TZlwqYBumGapOky3/rUPScd6I6poh5XpPNzya6gbipBasAs7xA==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.4"
+        "puppeteer-core": "21.3.5"
       }
     },
     "puppeteer-core": {
-      "version": "21.3.4",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.4.tgz",
-      "integrity": "sha512-iaG7ScTXOm9hlsBTBGGtr5dAAsA8IiWTx8E0Ghr0b5Ntl42bdcPS8EXjcERKocDhua2YqdlnFGs/cBxHY+VNyA==",
+      "version": "21.3.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.5.tgz",
+      "integrity": "sha512-C/yVgvob/HbUVTedhnURDruFkJYHEqJWlb6YltJGj/T7yzWdG4ouQ0JER8aX5g2RS4DMQ0xMNuhUVYMqC2QfnQ==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "chromium-bidi": "0.4.28",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.3.4"
+    "puppeteer": "^21.3.5"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.3.5)