### PR TITLE
bump puppeteer to v21.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.3.5"
+        "puppeteer": "^21.3.6"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -6673,23 +6673,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.3.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.5.tgz",
-      "integrity": "sha512-Lff7dgN7D1AHnPBgceZiZpcXVpKOcnSCtBy+TZlwqYBumGapOky3/rUPScd6I6poh5XpPNzya6gbipBasAs7xA==",
+      "version": "21.3.6",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.6.tgz",
+      "integrity": "sha512-ulK9+KLvdaVsG0EKbKyw/DCXCz88rsnrvIJg9tY8AmkGR01AxI4ZJTH9BJl1OE7cLfh2vxjBvY+xfvJod6rfgw==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.5"
+        "puppeteer-core": "21.3.6"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.3.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.5.tgz",
-      "integrity": "sha512-C/yVgvob/HbUVTedhnURDruFkJYHEqJWlb6YltJGj/T7yzWdG4ouQ0JER8aX5g2RS4DMQ0xMNuhUVYMqC2QfnQ==",
+      "version": "21.3.6",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.6.tgz",
+      "integrity": "sha512-ZH6tjTdRXwW2fx5W3jBbG+yUVQdDfZW1kjfwvWwMzsnKEli5ZwV70Zp97GOebHQHrK8zM3vX5VqI9sd48c9PnQ==",
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "chromium-bidi": "0.4.28",
@@ -13024,19 +13024,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.3.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.5.tgz",
-      "integrity": "sha512-Lff7dgN7D1AHnPBgceZiZpcXVpKOcnSCtBy+TZlwqYBumGapOky3/rUPScd6I6poh5XpPNzya6gbipBasAs7xA==",
+      "version": "21.3.6",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.6.tgz",
+      "integrity": "sha512-ulK9+KLvdaVsG0EKbKyw/DCXCz88rsnrvIJg9tY8AmkGR01AxI4ZJTH9BJl1OE7cLfh2vxjBvY+xfvJod6rfgw==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.5"
+        "puppeteer-core": "21.3.6"
       }
     },
     "puppeteer-core": {
-      "version": "21.3.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.5.tgz",
-      "integrity": "sha512-C/yVgvob/HbUVTedhnURDruFkJYHEqJWlb6YltJGj/T7yzWdG4ouQ0JER8aX5g2RS4DMQ0xMNuhUVYMqC2QfnQ==",
+      "version": "21.3.6",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.6.tgz",
+      "integrity": "sha512-ZH6tjTdRXwW2fx5W3jBbG+yUVQdDfZW1kjfwvWwMzsnKEli5ZwV70Zp97GOebHQHrK8zM3vX5VqI9sd48c9PnQ==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "chromium-bidi": "0.4.28",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.3.5"
+    "puppeteer": "^21.3.6"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.3.6)