### PR TITLE
bump puppeteer to v21.3.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.3.7"
+        "puppeteer": "^21.3.8"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -2452,9 +2452,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.28",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.28.tgz",
-      "integrity": "sha512-2HZ74QlAApJrEwcGlU/sUu0s4VS+FI3CJ09Toc9aE9VemMyhHZXeaROQgJKNRaYMUTUx6qIv1cLBs3F+vfgjSw==",
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.31.tgz",
+      "integrity": "sha512-OtvEg2JMRQrHsmLx4FV3u1Hf9waYxB5PmL+yM0HkFpc9H2x3TMbUqS+GP2/fC4399hzOO+EQF8uVU43By9ILag==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -6673,26 +6673,26 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.3.7",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.7.tgz",
-      "integrity": "sha512-C9rh0fxIZamrLqfX6VCJh8/MK4Io8jaELqSWKDT8rrWJLxzrv9Hy9aAlcZHySoOuJiZYxYJT71MRinyWiphylw==",
+      "version": "21.3.8",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.8.tgz",
+      "integrity": "sha512-4OrInVIAtDgcznENUV4Du4gYSZhRmbCkckvOoPstXrUH4JsQ3atSegY+9f/tOKCDB2qh7sXaszDcFEn+RymY0g==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.7"
+        "puppeteer-core": "21.3.8"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.3.7",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.7.tgz",
-      "integrity": "sha512-3IS/kl4TsaDLl171VdwtVAKCc2cwaFR5LrF/pEQQfUyIs6W1CuS8XwbIIJ6v6BCebv3x/NNtONTyOQdmTHPktg==",
+      "version": "21.3.8",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.8.tgz",
+      "integrity": "sha512-yv12E/+zZ7Lei5tJB4sUkSrsuqKibuYpYxLGbmtLUjjYIqGE5HKz9OUI2I/RFHEvF+pHi2bTbv5bWydeCGJ6Mw==",
       "dependencies": {
         "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.28",
+        "chromium-bidi": "0.4.31",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1179426",
@@ -9897,9 +9897,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.4.28",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.28.tgz",
-      "integrity": "sha512-2HZ74QlAApJrEwcGlU/sUu0s4VS+FI3CJ09Toc9aE9VemMyhHZXeaROQgJKNRaYMUTUx6qIv1cLBs3F+vfgjSw==",
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.31.tgz",
+      "integrity": "sha512-OtvEg2JMRQrHsmLx4FV3u1Hf9waYxB5PmL+yM0HkFpc9H2x3TMbUqS+GP2/fC4399hzOO+EQF8uVU43By9ILag==",
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -13024,22 +13024,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.3.7",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.7.tgz",
-      "integrity": "sha512-C9rh0fxIZamrLqfX6VCJh8/MK4Io8jaELqSWKDT8rrWJLxzrv9Hy9aAlcZHySoOuJiZYxYJT71MRinyWiphylw==",
+      "version": "21.3.8",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.8.tgz",
+      "integrity": "sha512-4OrInVIAtDgcznENUV4Du4gYSZhRmbCkckvOoPstXrUH4JsQ3atSegY+9f/tOKCDB2qh7sXaszDcFEn+RymY0g==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.7"
+        "puppeteer-core": "21.3.8"
       }
     },
     "puppeteer-core": {
-      "version": "21.3.7",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.7.tgz",
-      "integrity": "sha512-3IS/kl4TsaDLl171VdwtVAKCc2cwaFR5LrF/pEQQfUyIs6W1CuS8XwbIIJ6v6BCebv3x/NNtONTyOQdmTHPktg==",
+      "version": "21.3.8",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.8.tgz",
+      "integrity": "sha512-yv12E/+zZ7Lei5tJB4sUkSrsuqKibuYpYxLGbmtLUjjYIqGE5HKz9OUI2I/RFHEvF+pHi2bTbv5bWydeCGJ6Mw==",
       "requires": {
         "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.28",
+        "chromium-bidi": "0.4.31",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1179426",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.3.7"
+    "puppeteer": "^21.3.8"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.3.8)