### PR TITLE
bump puppeteer to v21.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.3.8"
+        "puppeteer": "^21.4.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.7.1.tgz",
-      "integrity": "sha512-nIb8SOBgDEMFY2iS2MdnUZOg2ikcYchRrBoF+wtdjieRFKR2uGRipHY/oFLo+2N6anDualyClPzGywTHRGrLfw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -1049,7 +1049,7 @@
         "proxy-agent": "6.3.1",
         "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
+        "yargs": "17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
@@ -1237,9 +1237,9 @@
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
-      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
+      "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -2452,9 +2452,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.31.tgz",
-      "integrity": "sha512-OtvEg2JMRQrHsmLx4FV3u1Hf9waYxB5PmL+yM0HkFpc9H2x3TMbUqS+GP2/fC4399hzOO+EQF8uVU43By9ILag==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
+      "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -3138,9 +3138,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1179426",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1179426.tgz",
-      "integrity": "sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg=="
+      "version": "0.0.1191157",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
+      "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -6673,29 +6673,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.3.8",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.8.tgz",
-      "integrity": "sha512-4OrInVIAtDgcznENUV4Du4gYSZhRmbCkckvOoPstXrUH4JsQ3atSegY+9f/tOKCDB2qh7sXaszDcFEn+RymY0g==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
+      "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "1.7.1",
+        "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.8"
+        "puppeteer-core": "21.4.0"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.3.8",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.8.tgz",
-      "integrity": "sha512-yv12E/+zZ7Lei5tJB4sUkSrsuqKibuYpYxLGbmtLUjjYIqGE5HKz9OUI2I/RFHEvF+pHi2bTbv5bWydeCGJ6Mw==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
+      "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
       "dependencies": {
-        "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.31",
+        "@puppeteer/browsers": "1.8.0",
+        "chromium-bidi": "0.4.32",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1179426",
+        "devtools-protocol": "0.0.1191157",
         "ws": "8.14.2"
       },
       "engines": {
@@ -7996,9 +7996,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -8810,9 +8810,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.7.1.tgz",
-      "integrity": "sha512-nIb8SOBgDEMFY2iS2MdnUZOg2ikcYchRrBoF+wtdjieRFKR2uGRipHY/oFLo+2N6anDualyClPzGywTHRGrLfw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -8820,7 +8820,7 @@
         "proxy-agent": "6.3.1",
         "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.1"
+        "yargs": "17.7.2"
       }
     },
     "@sinclair/typebox": {
@@ -8993,9 +8993,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.1.tgz",
-      "integrity": "sha512-CHzgNU3qYBnp/O4S3yv2tXPlvMTq0YWSTVg2/JYLqWZGHwwgJGAwd00poay/11asPq8wLFwHzubyInqHIFmmiw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
+      "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -9897,9 +9897,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.31.tgz",
-      "integrity": "sha512-OtvEg2JMRQrHsmLx4FV3u1Hf9waYxB5PmL+yM0HkFpc9H2x3TMbUqS+GP2/fC4399hzOO+EQF8uVU43By9ILag==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.32.tgz",
+      "integrity": "sha512-RJnw0PW3sNdx1WclINVfVVx8JUH+tWTHZNpnEzlcM+Qgvf40dUH34U7gJq+cc/0LE+rbPxeT6ldqWrCbUf4jeg==",
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "9.0.0"
@@ -10417,9 +10417,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1179426",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1179426.tgz",
-      "integrity": "sha512-KKC7IGwdOr7u9kTGgjUvGTov/z1s2H7oHi3zKCdR9eSDyCPia5CBi4aRhtp7d8uR7l0GS5UTDw3TjKGu5CqINg=="
+      "version": "0.0.1191157",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1191157.tgz",
+      "integrity": "sha512-Fu2mUhX7zkzLHMJZk5wQTiHdl1eJrhK0GypUoSzogUt51MmYEv/46pCz4PtGGFlr0f2ZyYDzzx5CPtbEkuvcTA=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -13024,25 +13024,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.3.8",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.3.8.tgz",
-      "integrity": "sha512-4OrInVIAtDgcznENUV4Du4gYSZhRmbCkckvOoPstXrUH4JsQ3atSegY+9f/tOKCDB2qh7sXaszDcFEn+RymY0g==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
+      "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
       "requires": {
-        "@puppeteer/browsers": "1.7.1",
+        "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.3.8"
+        "puppeteer-core": "21.4.0"
       }
     },
     "puppeteer-core": {
-      "version": "21.3.8",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.3.8.tgz",
-      "integrity": "sha512-yv12E/+zZ7Lei5tJB4sUkSrsuqKibuYpYxLGbmtLUjjYIqGE5HKz9OUI2I/RFHEvF+pHi2bTbv5bWydeCGJ6Mw==",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
+      "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
       "requires": {
-        "@puppeteer/browsers": "1.7.1",
-        "chromium-bidi": "0.4.31",
+        "@puppeteer/browsers": "1.8.0",
+        "chromium-bidi": "0.4.32",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1179426",
+        "devtools-protocol": "0.0.1191157",
         "ws": "8.14.2"
       }
     },
@@ -13974,9 +13974,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.3.8"
+    "puppeteer": "^21.4.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.4.0)