### PR TITLE
bump puppeteer to v21.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.4.0"
+        "puppeteer": "^21.4.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -6673,23 +6673,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
-      "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
+      "version": "21.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.1.tgz",
+      "integrity": "sha512-opJqQeYMjAB3ICG8lCF3wtSs9k05dozmrEMrHgo3ZWbISiy8qbv/yAJz/6Io221qSh3yURfVf6Z7crrlzKZjLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.4.0"
+        "puppeteer-core": "21.4.1"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
-      "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
+      "version": "21.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.1.tgz",
+      "integrity": "sha512-Lh0e+oGhUquxVOi1U701gTfFLFvw5gDBFh3CWpnfAvtItmyZKUce4R54VNfOJfi+KKnzhVPdB/lDrg65gdRIng==",
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.32",
@@ -13024,19 +13024,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.0.tgz",
-      "integrity": "sha512-KkiDe39NJxlw7fyiN6fieM9SVsewzt037nUZRoffNuFtYdAl5rRLVtleBuVZ5i1swK/R4CmA6Pbka/ytpFCu4Q==",
+      "version": "21.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.4.1.tgz",
+      "integrity": "sha512-opJqQeYMjAB3ICG8lCF3wtSs9k05dozmrEMrHgo3ZWbISiy8qbv/yAJz/6Io221qSh3yURfVf6Z7crrlzKZjLQ==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.4.0"
+        "puppeteer-core": "21.4.1"
       }
     },
     "puppeteer-core": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.0.tgz",
-      "integrity": "sha512-ONYjYgHItm6i9WdJf+MnRTRPB4HegwPbPfi1jjNN0LCW3rnNich/5hXgZFcn2oWvgFc8DWLDIcwly7C8z+EvIw==",
+      "version": "21.4.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.4.1.tgz",
+      "integrity": "sha512-Lh0e+oGhUquxVOi1U701gTfFLFvw5gDBFh3CWpnfAvtItmyZKUce4R54VNfOJfi+KKnzhVPdB/lDrg65gdRIng==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.32",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.4.0"
+    "puppeteer": "^21.4.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.4.1)