### PR TITLE
bump puppeteer to v21.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.5.0"
+        "puppeteer": "^21.5.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1237,9 +1237,9 @@
       "dev": true
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
-      "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -6673,23 +6673,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.0.tgz",
-      "integrity": "sha512-prvy9rdauyIaaEgefQRcw9zhQnYQbl8O1Gj5VJazKJ7kwNx703+Paw/1bwA+b96jj/S+r55hrmF5SfiEG5PUcg==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.1.tgz",
+      "integrity": "sha512-NkI06BXckVZeZUkODK+BbgGelQSu7uYEp9PaJDozxpwNRFDYoVfHQvd2G4dERoLdP6+qx4EBPwEhk4dEkQc2Kg==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.0"
+        "puppeteer-core": "21.5.1"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.0.tgz",
-      "integrity": "sha512-qG0RJ6qKgFz09UUZxDB9IcyTJGypQXMuE8WmEoHk7kgjutmRiOVv5RgsyUkY67AxDdBWx21bn1PHHRJnO/6b4A==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.1.tgz",
+      "integrity": "sha512-u6c3SZKAOaOQogaTkQvllxT/o2PP16wkbrUWINtMhfvrB4ko+xwqC1pb+vyCPMmNUh3N/CX5YGqb3DWx2fUPSQ==",
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.33",
@@ -8993,9 +8993,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.2.tgz",
-      "integrity": "sha512-Km7XAtUIduROw7QPgvcft0lIupeG8a8rdKL8RiSyKvlE7dYY31fEn41HVuQsRFDuROA8tA4K2UVL+WdfFmErBA==",
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -13024,19 +13024,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.0.tgz",
-      "integrity": "sha512-prvy9rdauyIaaEgefQRcw9zhQnYQbl8O1Gj5VJazKJ7kwNx703+Paw/1bwA+b96jj/S+r55hrmF5SfiEG5PUcg==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.1.tgz",
+      "integrity": "sha512-NkI06BXckVZeZUkODK+BbgGelQSu7uYEp9PaJDozxpwNRFDYoVfHQvd2G4dERoLdP6+qx4EBPwEhk4dEkQc2Kg==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.0"
+        "puppeteer-core": "21.5.1"
       }
     },
     "puppeteer-core": {
-      "version": "21.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.0.tgz",
-      "integrity": "sha512-qG0RJ6qKgFz09UUZxDB9IcyTJGypQXMuE8WmEoHk7kgjutmRiOVv5RgsyUkY67AxDdBWx21bn1PHHRJnO/6b4A==",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.1.tgz",
+      "integrity": "sha512-u6c3SZKAOaOQogaTkQvllxT/o2PP16wkbrUWINtMhfvrB4ko+xwqC1pb+vyCPMmNUh3N/CX5YGqb3DWx2fUPSQ==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.33",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.5.0"
+    "puppeteer": "^21.5.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.5.1)