### PR TITLE
bump puppeteer to v21.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.5.1"
+        "puppeteer": "^21.5.2"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -6673,23 +6673,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.1.tgz",
-      "integrity": "sha512-NkI06BXckVZeZUkODK+BbgGelQSu7uYEp9PaJDozxpwNRFDYoVfHQvd2G4dERoLdP6+qx4EBPwEhk4dEkQc2Kg==",
+      "version": "21.5.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
+      "integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.1"
+        "puppeteer-core": "21.5.2"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.1.tgz",
-      "integrity": "sha512-u6c3SZKAOaOQogaTkQvllxT/o2PP16wkbrUWINtMhfvrB4ko+xwqC1pb+vyCPMmNUh3N/CX5YGqb3DWx2fUPSQ==",
+      "version": "21.5.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
+      "integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
       "dependencies": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.33",
@@ -6699,7 +6699,7 @@
         "ws": "8.14.2"
       },
       "engines": {
-        "node": ">=16.3.0"
+        "node": ">=16.13.2"
       }
     },
     "node_modules/query-string": {
@@ -13024,19 +13024,19 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.1.tgz",
-      "integrity": "sha512-NkI06BXckVZeZUkODK+BbgGelQSu7uYEp9PaJDozxpwNRFDYoVfHQvd2G4dERoLdP6+qx4EBPwEhk4dEkQc2Kg==",
+      "version": "21.5.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
+      "integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.5.1"
+        "puppeteer-core": "21.5.2"
       }
     },
     "puppeteer-core": {
-      "version": "21.5.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.1.tgz",
-      "integrity": "sha512-u6c3SZKAOaOQogaTkQvllxT/o2PP16wkbrUWINtMhfvrB4ko+xwqC1pb+vyCPMmNUh3N/CX5YGqb3DWx2fUPSQ==",
+      "version": "21.5.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
+      "integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
       "requires": {
         "@puppeteer/browsers": "1.8.0",
         "chromium-bidi": "0.4.33",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.5.1"
+    "puppeteer": "^21.5.2"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.5.2)