### PR TITLE
bump puppeteer to v21.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.6.0"
+        "puppeteer": "^21.6.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1612,9 +1612,9 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -6673,14 +6673,14 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.0.tgz",
-      "integrity": "sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==",
+      "version": "21.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.1.tgz",
+      "integrity": "sha512-O+pbc61oj8ln6m8EJKncrsQFmytgRyFYERtk190PeLbJn5JKpmmynn2p1PiFrlhCitAQXLJ0MOy7F0TeyCRqBg==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.9.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.6.0"
+        "puppeteer-core": "21.6.1"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6690,16 +6690,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
-      "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
+      "version": "21.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.1.tgz",
+      "integrity": "sha512-0chaaK/RL9S1U3bsyR4fUeUfoj51vNnjWvXgG6DcsyMjwYNpLcAThv187i1rZCo7QhJP0wZN8plQkjNyrq2h+A==",
       "dependencies": {
         "@puppeteer/browsers": "1.9.0",
         "chromium-bidi": "0.5.1",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1203626",
-        "ws": "8.14.2"
+        "ws": "8.15.1"
       },
       "engines": {
         "node": ">=16.13.2"
@@ -7958,9 +7958,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -9256,9 +9256,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-ftp": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-      "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA=="
     },
     "bin-build": {
       "version": "3.0.0",
@@ -13027,26 +13027,26 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.0.tgz",
-      "integrity": "sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==",
+      "version": "21.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.1.tgz",
+      "integrity": "sha512-O+pbc61oj8ln6m8EJKncrsQFmytgRyFYERtk190PeLbJn5JKpmmynn2p1PiFrlhCitAQXLJ0MOy7F0TeyCRqBg==",
       "requires": {
         "@puppeteer/browsers": "1.9.0",
         "cosmiconfig": "8.3.6",
-        "puppeteer-core": "21.6.0"
+        "puppeteer-core": "21.6.1"
       }
     },
     "puppeteer-core": {
-      "version": "21.6.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
-      "integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
+      "version": "21.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.1.tgz",
+      "integrity": "sha512-0chaaK/RL9S1U3bsyR4fUeUfoj51vNnjWvXgG6DcsyMjwYNpLcAThv187i1rZCo7QhJP0wZN8plQkjNyrq2h+A==",
       "requires": {
         "@puppeteer/browsers": "1.9.0",
         "chromium-bidi": "0.5.1",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1203626",
-        "ws": "8.14.2"
+        "ws": "8.15.1"
       }
     },
     "query-string": {
@@ -13956,9 +13956,9 @@
       }
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.6.0"
+    "puppeteer": "^21.6.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.6.1)