### PR TITLE
bump puppeteer to v21.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^21.9.0"
+        "puppeteer": "^21.10.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -2499,12 +2499,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.4.tgz",
-      "integrity": "sha512-p9CdiHl0xNh4P7oVa44zXgJJw+pvnHXFDB+tVdo25xaPLgQDVf2kQO+TDxD2fp2Evqi7vs/vGRINMzl1qJrWiw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.6.tgz",
+      "integrity": "sha512-ber8smgoAs4EqSUHRb0I8fpx371ZmvsdQav8HRM9oO4fk5Ox16vQiNYXlsZkRj4FfvVL2dCef+zBFQixp+79CA==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -6770,14 +6770,14 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "21.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.9.0.tgz",
-      "integrity": "sha512-vcLR81Rp+MBrgqhiXZfpwEBbyKTa88Hd+8Al3+emWzcJb9evLLSfUYli0QUqhofPFrXsO2A/dAF9OunyOivL6w==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.10.0.tgz",
+      "integrity": "sha512-Y1yQjcLE00hHTDAmv3M3A6hhW0Ytjdp6xr6nyjl7FZ7E7hzp/6Rsw80FbaTJzJHFCplBNi082wrgynbmD7RlYw==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.9.1",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "21.9.0"
+        "puppeteer-core": "21.10.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6787,12 +6787,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "21.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.9.0.tgz",
-      "integrity": "sha512-QgowcczLAoLWlV38s3y3VuEvjJGfKU5rR6Q23GUbiGOaiQi+QpaWQ+aXdzP9LHVSUPmHdAaWhcvMztYSw3f8gQ==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.10.0.tgz",
+      "integrity": "sha512-NVaqO3K462qwMuLO4Gurs/Mau1Wss+08QgNYzF0dIqZWMvpskrt/TbxbmHU+7zMTUOvPEq/lR4BLJmjMBgBGfQ==",
       "dependencies": {
         "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.4",
+        "chromium-bidi": "0.5.6",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1232444",
@@ -7928,9 +7928,9 @@
       }
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -10029,12 +10029,12 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.4.tgz",
-      "integrity": "sha512-p9CdiHl0xNh4P7oVa44zXgJJw+pvnHXFDB+tVdo25xaPLgQDVf2kQO+TDxD2fp2Evqi7vs/vGRINMzl1qJrWiw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.6.tgz",
+      "integrity": "sha512-ber8smgoAs4EqSUHRb0I8fpx371ZmvsdQav8HRM9oO4fk5Ox16vQiNYXlsZkRj4FfvVL2dCef+zBFQixp+79CA==",
       "requires": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "9.0.0"
+        "urlpattern-polyfill": "10.0.0"
       }
     },
     "ci-info": {
@@ -13190,22 +13190,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "21.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.9.0.tgz",
-      "integrity": "sha512-vcLR81Rp+MBrgqhiXZfpwEBbyKTa88Hd+8Al3+emWzcJb9evLLSfUYli0QUqhofPFrXsO2A/dAF9OunyOivL6w==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.10.0.tgz",
+      "integrity": "sha512-Y1yQjcLE00hHTDAmv3M3A6hhW0Ytjdp6xr6nyjl7FZ7E7hzp/6Rsw80FbaTJzJHFCplBNi082wrgynbmD7RlYw==",
       "requires": {
         "@puppeteer/browsers": "1.9.1",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "21.9.0"
+        "puppeteer-core": "21.10.0"
       }
     },
     "puppeteer-core": {
-      "version": "21.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.9.0.tgz",
-      "integrity": "sha512-QgowcczLAoLWlV38s3y3VuEvjJGfKU5rR6Q23GUbiGOaiQi+QpaWQ+aXdzP9LHVSUPmHdAaWhcvMztYSw3f8gQ==",
+      "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.10.0.tgz",
+      "integrity": "sha512-NVaqO3K462qwMuLO4Gurs/Mau1Wss+08QgNYzF0dIqZWMvpskrt/TbxbmHU+7zMTUOvPEq/lR4BLJmjMBgBGfQ==",
       "requires": {
         "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.4",
+        "chromium-bidi": "0.5.6",
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1232444",
@@ -14020,9 +14020,9 @@
       "integrity": "sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A=="
     },
     "urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^21.9.0"
+    "puppeteer": "^21.10.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.10.0)