### PR TITLE
bump puppeteer to v22.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.5.0"
+        "puppeteer": "^22.6.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg=="
+      "version": "0.0.1262051",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
+      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -6811,14 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.5.0.tgz",
-      "integrity": "sha512-PNVflixb6w3FMhehYhLcaQHTCcNKVkjxekzyvWr0n0yBnhUYF0ZhiG4J1I14Mzui2oW8dGvUD8kbXj0GiN1pFg==",
+      "version": "22.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.0.tgz",
+      "integrity": "sha512-TYeza4rl1YXfxqUVw/0hWUWYX5cicnf6qu5kkDV+t7QrESCjMoSNnva4ZA/MRGQ03HnB9BOFw9nxs/SKek5KDA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.0",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.5.0"
+        "devtools-protocol": "0.0.1262051",
+        "puppeteer-core": "22.6.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6828,14 +6829,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.5.0.tgz",
-      "integrity": "sha512-bcfmM1nNSysjnES/ZZ1KdwFAFFGL3N76qRpisBb4WL7f4UAD4vPDxlhKZ1HJCDgMSWeYmeder4kftyp6lKqMYg==",
+      "version": "22.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.0.tgz",
+      "integrity": "sha512-xclyGFhxHfZ9l62uXFm+JpgtJHLIZ1qHc7iR4eaIqBNKA5Dg2sDr8yvylfCx5bMN89QWIaxpV6IHsy0qUynK/g==",
       "dependencies": {
         "@puppeteer/browsers": "2.2.0",
         "chromium-bidi": "0.5.13",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1249869",
+        "devtools-protocol": "0.0.1262051",
         "ws": "8.16.0"
       },
       "engines": {
@@ -10613,9 +10614,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg=="
+      "version": "0.0.1262051",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
+      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -13262,24 +13263,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.5.0.tgz",
-      "integrity": "sha512-PNVflixb6w3FMhehYhLcaQHTCcNKVkjxekzyvWr0n0yBnhUYF0ZhiG4J1I14Mzui2oW8dGvUD8kbXj0GiN1pFg==",
+      "version": "22.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.0.tgz",
+      "integrity": "sha512-TYeza4rl1YXfxqUVw/0hWUWYX5cicnf6qu5kkDV+t7QrESCjMoSNnva4ZA/MRGQ03HnB9BOFw9nxs/SKek5KDA==",
       "requires": {
         "@puppeteer/browsers": "2.2.0",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.5.0"
+        "devtools-protocol": "0.0.1262051",
+        "puppeteer-core": "22.6.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.5.0.tgz",
-      "integrity": "sha512-bcfmM1nNSysjnES/ZZ1KdwFAFFGL3N76qRpisBb4WL7f4UAD4vPDxlhKZ1HJCDgMSWeYmeder4kftyp6lKqMYg==",
+      "version": "22.6.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.0.tgz",
+      "integrity": "sha512-xclyGFhxHfZ9l62uXFm+JpgtJHLIZ1qHc7iR4eaIqBNKA5Dg2sDr8yvylfCx5bMN89QWIaxpV6IHsy0qUynK/g==",
       "requires": {
         "@puppeteer/browsers": "2.2.0",
         "chromium-bidi": "0.5.13",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1249869",
+        "devtools-protocol": "0.0.1262051",
         "ws": "8.16.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.5.0"
+    "puppeteer": "^22.6.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.6.0)