### PR TITLE
bump puppeteer to v22.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.6.2"
+        "puppeteer": "^22.6.3"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.0.tgz",
-      "integrity": "sha512-MC7LxpcBtdfTbzwARXIkqGZ1Osn3nnZJlm+i0+VqHl72t//Xwl9wICrXT8BwtgC6s1xJNHsxOpvzISUqe92+sw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
+      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.6.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.2.tgz",
-      "integrity": "sha512-3GMAJ9adPUSdIHGuYV1b1RqRB6D2UScjnq779uZsvpAP6HOWw2+9ezZiUZaAXVST+Ku7KWsxOjkctEvRasJClA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.3.tgz",
+      "integrity": "sha512-KZOnthMbvr4+7cPKFeeOCJPe8DzOKGC0GbMXmZKOP/YusXQ6sqxA0vt6frstZq3rUJ277qXHlZNFf01VVwdHKw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.2.0",
+        "@puppeteer/browsers": "2.2.1",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.2"
+        "puppeteer-core": "22.6.3"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,11 +6829,11 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.6.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.2.tgz",
-      "integrity": "sha512-Sws/9V2/7nFrn3MSsRPHn1pXJMIFn6FWHhoMFMUBXQwVvcBstRIa9yW8sFfxePzb56W1xNfSYzPRnyAd0+qRVQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.3.tgz",
+      "integrity": "sha512-YrTAak5zCTWVTnVaCK1b7FD1qFCCT9bSvQhLzamnIsJ57/tfuXiT8ZvPJR2SBfahyFTYFCcaZAd/Npow3lmDGA==",
       "dependencies": {
-        "@puppeteer/browsers": "2.2.0",
+        "@puppeteer/browsers": "2.2.1",
         "chromium-bidi": "0.5.16",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1262051",
@@ -8938,9 +8938,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.0.tgz",
-      "integrity": "sha512-MC7LxpcBtdfTbzwARXIkqGZ1Osn3nnZJlm+i0+VqHl72t//Xwl9wICrXT8BwtgC6s1xJNHsxOpvzISUqe92+sw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
+      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -13263,22 +13263,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.6.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.2.tgz",
-      "integrity": "sha512-3GMAJ9adPUSdIHGuYV1b1RqRB6D2UScjnq779uZsvpAP6HOWw2+9ezZiUZaAXVST+Ku7KWsxOjkctEvRasJClA==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.3.tgz",
+      "integrity": "sha512-KZOnthMbvr4+7cPKFeeOCJPe8DzOKGC0GbMXmZKOP/YusXQ6sqxA0vt6frstZq3rUJ277qXHlZNFf01VVwdHKw==",
       "requires": {
-        "@puppeteer/browsers": "2.2.0",
+        "@puppeteer/browsers": "2.2.1",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.2"
+        "puppeteer-core": "22.6.3"
       }
     },
     "puppeteer-core": {
-      "version": "22.6.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.2.tgz",
-      "integrity": "sha512-Sws/9V2/7nFrn3MSsRPHn1pXJMIFn6FWHhoMFMUBXQwVvcBstRIa9yW8sFfxePzb56W1xNfSYzPRnyAd0+qRVQ==",
+      "version": "22.6.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.3.tgz",
+      "integrity": "sha512-YrTAak5zCTWVTnVaCK1b7FD1qFCCT9bSvQhLzamnIsJ57/tfuXiT8ZvPJR2SBfahyFTYFCcaZAd/Npow3lmDGA==",
       "requires": {
-        "@puppeteer/browsers": "2.2.0",
+        "@puppeteer/browsers": "2.2.1",
         "chromium-bidi": "0.5.16",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1262051",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.6.2"
+    "puppeteer": "^22.6.3"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.6.3)