### PR TITLE
bump puppeteer to v22.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.6.4"
+        "puppeteer": "^22.6.5"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
-      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
+      "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.6.4",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.4.tgz",
-      "integrity": "sha512-J9hXNwZmuqKDmNMj6kednZH8jzbdX9735NQfQJrq5LRD4nHisAMyW9pCD7glKi+iM7RV9JkesI1MYhdsN+0ZSQ==",
+      "version": "22.6.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.5.tgz",
+      "integrity": "sha512-YuoRKGj3MxHhUwrey7vmNvU4odGdUdNsj1ee8pfcqQlLWIXfMOXZCAXh8xdzpZESHH3tCGWp2xmPZE8E6iUEWg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.2.1",
+        "@puppeteer/browsers": "2.2.2",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.4"
+        "puppeteer-core": "22.6.5"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,11 +6829,11 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.6.4",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.4.tgz",
-      "integrity": "sha512-QtfJwPmqQec3EHc6LqbEz03vSiuVAr9bYp0TV87dLoreev6ZevsXdLgOfQgoA3GocrsSe/eUf7NRPQ1lQfsc3w==",
+      "version": "22.6.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.5.tgz",
+      "integrity": "sha512-s0/5XkAWe0/dWISiljdrybjwDCHhgN31Nu/wznOZPKeikgcJtZtbvPKBz0t802XWqfSQnQDt3L6xiAE5JLlfuw==",
       "dependencies": {
-        "@puppeteer/browsers": "2.2.1",
+        "@puppeteer/browsers": "2.2.2",
         "chromium-bidi": "0.5.17",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1262051",
@@ -8938,9 +8938,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
-      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
+      "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -13263,22 +13263,22 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.6.4",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.4.tgz",
-      "integrity": "sha512-J9hXNwZmuqKDmNMj6kednZH8jzbdX9735NQfQJrq5LRD4nHisAMyW9pCD7glKi+iM7RV9JkesI1MYhdsN+0ZSQ==",
+      "version": "22.6.5",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.5.tgz",
+      "integrity": "sha512-YuoRKGj3MxHhUwrey7vmNvU4odGdUdNsj1ee8pfcqQlLWIXfMOXZCAXh8xdzpZESHH3tCGWp2xmPZE8E6iUEWg==",
       "requires": {
-        "@puppeteer/browsers": "2.2.1",
+        "@puppeteer/browsers": "2.2.2",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.4"
+        "puppeteer-core": "22.6.5"
       }
     },
     "puppeteer-core": {
-      "version": "22.6.4",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.4.tgz",
-      "integrity": "sha512-QtfJwPmqQec3EHc6LqbEz03vSiuVAr9bYp0TV87dLoreev6ZevsXdLgOfQgoA3GocrsSe/eUf7NRPQ1lQfsc3w==",
+      "version": "22.6.5",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.5.tgz",
+      "integrity": "sha512-s0/5XkAWe0/dWISiljdrybjwDCHhgN31Nu/wznOZPKeikgcJtZtbvPKBz0t802XWqfSQnQDt3L6xiAE5JLlfuw==",
       "requires": {
-        "@puppeteer/browsers": "2.2.1",
+        "@puppeteer/browsers": "2.2.2",
         "chromium-bidi": "0.5.17",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1262051",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.6.4"
+    "puppeteer": "^22.6.5"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.6.5)