### PR TITLE
bump puppeteer to v22.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.6.5"
+        "puppeteer": "^22.7.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1262051",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
-      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
+      "version": "0.0.1273771",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
+      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.5.tgz",
-      "integrity": "sha512-YuoRKGj3MxHhUwrey7vmNvU4odGdUdNsj1ee8pfcqQlLWIXfMOXZCAXh8xdzpZESHH3tCGWp2xmPZE8E6iUEWg==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.0.tgz",
+      "integrity": "sha512-s1ulKFZKW3lwWCtNu0VrRLfRaanFHxIv7F8UFYpLo8dPTZcI4wB4EAOD0sKT3SKP+1Rsjodb9WFsK78yKQ6i9Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.2",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.5"
+        "devtools-protocol": "0.0.1273771",
+        "puppeteer-core": "22.7.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,14 +6829,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.5.tgz",
-      "integrity": "sha512-s0/5XkAWe0/dWISiljdrybjwDCHhgN31Nu/wznOZPKeikgcJtZtbvPKBz0t802XWqfSQnQDt3L6xiAE5JLlfuw==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.0.tgz",
+      "integrity": "sha512-9Q+L3VD7cfhXnxv6AqwTHsVb/+/uXENByhPrgvwQ49wvzQwtf1d6b7v6gpoG3tpRdwYjxoV1eHTD8tFahww09g==",
       "dependencies": {
         "@puppeteer/browsers": "2.2.2",
         "chromium-bidi": "0.5.17",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1262051",
+        "devtools-protocol": "0.0.1273771",
         "ws": "8.16.0"
       },
       "engines": {
@@ -10614,9 +10614,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1262051",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
-      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
+      "version": "0.0.1273771",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
+      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -13263,25 +13263,25 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.6.5.tgz",
-      "integrity": "sha512-YuoRKGj3MxHhUwrey7vmNvU4odGdUdNsj1ee8pfcqQlLWIXfMOXZCAXh8xdzpZESHH3tCGWp2xmPZE8E6iUEWg==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.0.tgz",
+      "integrity": "sha512-s1ulKFZKW3lwWCtNu0VrRLfRaanFHxIv7F8UFYpLo8dPTZcI4wB4EAOD0sKT3SKP+1Rsjodb9WFsK78yKQ6i9Q==",
       "requires": {
         "@puppeteer/browsers": "2.2.2",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1262051",
-        "puppeteer-core": "22.6.5"
+        "devtools-protocol": "0.0.1273771",
+        "puppeteer-core": "22.7.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.6.5",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.5.tgz",
-      "integrity": "sha512-s0/5XkAWe0/dWISiljdrybjwDCHhgN31Nu/wznOZPKeikgcJtZtbvPKBz0t802XWqfSQnQDt3L6xiAE5JLlfuw==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.0.tgz",
+      "integrity": "sha512-9Q+L3VD7cfhXnxv6AqwTHsVb/+/uXENByhPrgvwQ49wvzQwtf1d6b7v6gpoG3tpRdwYjxoV1eHTD8tFahww09g==",
       "requires": {
         "@puppeteer/browsers": "2.2.2",
         "chromium-bidi": "0.5.17",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1262051",
+        "devtools-protocol": "0.0.1273771",
         "ws": "8.16.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.6.5"
+    "puppeteer": "^22.7.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.7.0)