### PR TITLE
bump puppeteer to v22.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.7.0"
+        "puppeteer": "^22.7.1"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -1039,9 +1039,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
-      "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
+      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -2547,9 +2547,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.17.tgz",
-      "integrity": "sha512-BqOuIWUgTPj8ayuBFJUYCCuwIcwjBsb3/614P7tt1bEPJ4i1M0kCdIl0Wi9xhtswBXnfO2bTpTMkHD71H8rJMg==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
+      "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
       "dependencies": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.0.tgz",
-      "integrity": "sha512-s1ulKFZKW3lwWCtNu0VrRLfRaanFHxIv7F8UFYpLo8dPTZcI4wB4EAOD0sKT3SKP+1Rsjodb9WFsK78yKQ6i9Q==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
+      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.2.2",
+        "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.0"
+        "puppeteer-core": "22.7.1"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,12 +6829,12 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.0.tgz",
-      "integrity": "sha512-9Q+L3VD7cfhXnxv6AqwTHsVb/+/uXENByhPrgvwQ49wvzQwtf1d6b7v6gpoG3tpRdwYjxoV1eHTD8tFahww09g==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
+      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
       "dependencies": {
-        "@puppeteer/browsers": "2.2.2",
-        "chromium-bidi": "0.5.17",
+        "@puppeteer/browsers": "2.2.3",
+        "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1273771",
         "ws": "8.16.0"
@@ -8938,9 +8938,9 @@
       }
     },
     "@puppeteer/browsers": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
-      "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
+      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -10101,9 +10101,9 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chromium-bidi": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.17.tgz",
-      "integrity": "sha512-BqOuIWUgTPj8ayuBFJUYCCuwIcwjBsb3/614P7tt1bEPJ4i1M0kCdIl0Wi9xhtswBXnfO2bTpTMkHD71H8rJMg==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.19.tgz",
+      "integrity": "sha512-UA6zL77b7RYCjJkZBsZ0wlvCTD+jTjllZ8f6wdO4buevXgTZYjV+XLB9CiEa2OuuTGGTLnI7eN9I60YxuALGQg==",
       "requires": {
         "mitt": "3.0.1",
         "urlpattern-polyfill": "10.0.0",
@@ -13263,23 +13263,23 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.0.tgz",
-      "integrity": "sha512-s1ulKFZKW3lwWCtNu0VrRLfRaanFHxIv7F8UFYpLo8dPTZcI4wB4EAOD0sKT3SKP+1Rsjodb9WFsK78yKQ6i9Q==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
+      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
       "requires": {
-        "@puppeteer/browsers": "2.2.2",
+        "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.0"
+        "puppeteer-core": "22.7.1"
       }
     },
     "puppeteer-core": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.0.tgz",
-      "integrity": "sha512-9Q+L3VD7cfhXnxv6AqwTHsVb/+/uXENByhPrgvwQ49wvzQwtf1d6b7v6gpoG3tpRdwYjxoV1eHTD8tFahww09g==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
+      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
       "requires": {
-        "@puppeteer/browsers": "2.2.2",
-        "chromium-bidi": "0.5.17",
+        "@puppeteer/browsers": "2.2.3",
+        "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1273771",
         "ws": "8.16.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.7.0"
+    "puppeteer": "^22.7.1"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.7.1)