### PR TITLE
bump puppeteer to v22.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.7.1"
+        "puppeteer": "^22.9.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1273771",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
-      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
+      "version": "0.0.1286932",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
+      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
-      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.9.0.tgz",
+      "integrity": "sha512-yNux2cm6Sfik4lNLNjJ25Cdn9spJRbMXxl1YZtVZCEhEeej1sFlCvZ/Cr64LhgyJOuvz3iq2uk+RLFpQpGwrjw==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.1"
+        "devtools-protocol": "0.0.1286932",
+        "puppeteer-core": "22.9.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,15 +6829,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
-      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
+      "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1273771",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1286932",
+        "ws": "8.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -8075,9 +8075,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10614,9 +10614,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1273771",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
-      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
+      "version": "0.0.1286932",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
+      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -13263,26 +13263,26 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
-      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.9.0.tgz",
+      "integrity": "sha512-yNux2cm6Sfik4lNLNjJ25Cdn9spJRbMXxl1YZtVZCEhEeej1sFlCvZ/Cr64LhgyJOuvz3iq2uk+RLFpQpGwrjw==",
       "requires": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.1"
+        "devtools-protocol": "0.0.1286932",
+        "puppeteer-core": "22.9.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
-      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.9.0.tgz",
+      "integrity": "sha512-Q2SYVZ1SIE7jCd/Pp+1/mNLFtdJfGvAF+CqOTDG8HcCNCiBvoXfopXfOfMHQ/FueXhGfJW/I6DartWv6QzpNGg==",
       "requires": {
         "@puppeteer/browsers": "2.2.3",
         "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1273771",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1286932",
+        "ws": "8.17.0"
       }
     },
     "query-string": {
@@ -14167,9 +14167,9 @@
       }
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.7.1"
+    "puppeteer": "^22.9.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.9.0)