### PR TITLE
bump puppeteer to v22.10.0 [HeadlessChrome/125.0.0.0]

### DIFF
--- a/core/scope.js
+++ b/core/scope.js
@@ -1,7 +1,7 @@
 /**
  * phantomas browser "scope" with helper code
  *
- * Code below is executed in page's "scope" (injected by lib/browser.js)
+ * Code below is executed in page's "scope" (injected by the scope.injectJs() helper)
  */
 /* istanbul ignore next */
 (function coreScope(scope) {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -179,7 +179,7 @@ Browser.prototype.init = async (phantomasOptions) => {
     var meta = responses[data.requestId];
 
     /* istanbul ignore if */
-    if (typeof meta === "undefined") {
+    if (typeof meta?.response === "undefined") {
       // the browser sometimes looses trace of a request, let's ignore.
       networkDebug(
         "Can't find request id %d in previous requests",

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,9 @@ function phantomas(url, opts) {
         },
 
         // @see https://pptr.dev/api/puppeteer.page.evaluateonnewdocument
+        // Adds a function which would be invoked in when:
+        //  - the child frame is attached or navigated
+        //  - the page is navigated
         injectJs: async (script) => {
           const debug = require("debug")("phantomas:injectJs");
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ function phantomas(url, opts) {
           return page.$$(selector);
         },
 
-        // @see https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pageevaluateonnewdocumentpagefunction-args
+        // @see https://pptr.dev/api/puppeteer.page.evaluateonnewdocument
         injectJs: async (script) => {
           const debug = require("debug")("phantomas:injectJs");
 
@@ -98,7 +98,9 @@ function phantomas(url, opts) {
             suffix = "}";
 
           const preloadFile =
-            prefix + require("fs").readFileSync(script, "utf8") + suffix;
+            prefix +
+            (await require("fs/promises").readFile(script, "utf8")) +
+            suffix;
 
           await page.evaluateOnNewDocument(preloadFile);
 
@@ -117,8 +119,9 @@ function phantomas(url, opts) {
       // @see https://github.com/GoogleChrome/puppeteer/blob/v1.11.0/docs/api.md#pageexposefunctionname-puppeteerfunction
       await page.exposeFunction("__phantomas_emit", scope.emit);
 
-      // Inject helper code into the browser's scope
-      events.on("init", () => {
+      // Inject helper code into the browser's scope (but only once!)
+      events.once("init", () => {
+        debug("onInit: injecting the core/scope.js ...");
         scope.injectJs(__dirname + "/../core/scope.js");
       });
 

--- a/modules/domComplexity/scope.js
+++ b/modules/domComplexity/scope.js
@@ -92,13 +92,17 @@
     })();
 
     // count <iframe> tags
-    document.querySelectorAll("iframe").forEach(function (iframe) {
-      phantomas.incrMetric("iframesCount"); // @desc number of iframe nodes
+    const iframes = document.querySelectorAll("iframe");
+    phantomas.setMetric("iframesCount", iframes.length); // @desc number of iframe nodes
+
+    for (const iframe of iframes) {
+      phantomas.log(`iframe: ${iframe.src}`);
+
       phantomas.addOffender("iframesCount", {
         element: phantomas.getDOMPath(iframe),
         url: iframe.src,
       });
-    });
+    }
 
     phantomas.spyEnabled(true);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "decamelize": "^5.0.0",
         "fast-stats": "0.0.6",
         "js-yaml": "^4.0.0",
-        "puppeteer": "^22.7.1"
+        "puppeteer": "^22.10.0"
       },
       "bin": {
         "phantomas": "bin/phantomas.js"
@@ -3226,9 +3226,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1273771",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
-      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
+      "version": "0.0.1286932",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
+      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA=="
     },
     "node_modules/diff-sequences": {
       "version": "28.1.1",
@@ -6811,15 +6811,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
-      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.10.0.tgz",
+      "integrity": "sha512-ZOkZd6a6t0BdKcWb0wAYHWQqCfdlN1PPnXOmg/XNrbo6gJhYWFX4qCNb6ahSn8TpAqBqLCoD4Q010F7GwOM7mA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.1"
+        "devtools-protocol": "0.0.1286932",
+        "puppeteer-core": "22.10.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -6829,15 +6829,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
-      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.10.0.tgz",
+      "integrity": "sha512-I54J4Vy4I07UHsgB1QSmuFoF7KNQjJWcvFBPhtY+ezMdBfwgGDr8dzYrJa11aPgP9kxIUHjhktcMmmfJkOAtTw==",
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1273771",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1286932",
+        "ws": "8.17.0"
       },
       "engines": {
         "node": ">=18"
@@ -8075,9 +8075,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10614,9 +10614,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1273771",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
-      "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
+      "version": "0.0.1286932",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1286932.tgz",
+      "integrity": "sha512-wu58HMQll9voDjR4NlPyoDEw1syfzaBNHymMMZ/QOXiHRNluOnDgu9hp1yHOKYoMlxCh4lSSiugLITe6Fvu1eA=="
     },
     "diff-sequences": {
       "version": "28.1.1",
@@ -13263,26 +13263,26 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.1.tgz",
-      "integrity": "sha512-JBCBCwQ9+dyPp5haqeecgv0N0vgWFx44woUeKJaPeJT8CU3RXrd8F/tqJQbuAmcWlbMhYJSlTJkIFrwVAs6BNA==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.10.0.tgz",
+      "integrity": "sha512-ZOkZd6a6t0BdKcWb0wAYHWQqCfdlN1PPnXOmg/XNrbo6gJhYWFX4qCNb6ahSn8TpAqBqLCoD4Q010F7GwOM7mA==",
       "requires": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
-        "devtools-protocol": "0.0.1273771",
-        "puppeteer-core": "22.7.1"
+        "devtools-protocol": "0.0.1286932",
+        "puppeteer-core": "22.10.0"
       }
     },
     "puppeteer-core": {
-      "version": "22.7.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.1.tgz",
-      "integrity": "sha512-jD7T7yN7PWGuJmNT0TAEboA26s0VVnvbgCxqgQIF+eNQW2u71ENaV2JwzSJiCHO+e72H4Ue6AgKD9USQ8xAcOQ==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.10.0.tgz",
+      "integrity": "sha512-I54J4Vy4I07UHsgB1QSmuFoF7KNQjJWcvFBPhtY+ezMdBfwgGDr8dzYrJa11aPgP9kxIUHjhktcMmmfJkOAtTw==",
       "requires": {
         "@puppeteer/browsers": "2.2.3",
         "chromium-bidi": "0.5.19",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1273771",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1286932",
+        "ws": "8.17.0"
       }
     },
     "query-string": {
@@ -14167,9 +14167,9 @@
       }
     },
     "ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "requires": {}
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "decamelize": "^5.0.0",
     "fast-stats": "0.0.6",
     "js-yaml": "^4.0.0",
-    "puppeteer": "^22.7.1"
+    "puppeteer": "^22.10.0"
   },
   "devDependencies": {
     "@jest/globals": "^28.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 89,
-        "branches": 85,
+        "branches": 80,
         "functions": 89,
         "lines": 89
       }


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.10.0)