### PR TITLE
bump puppeteer to v22.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "phantomas",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "phantomas",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "analyze-css": "^2.1.89",


### PR DESCRIPTION
[Release notes](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v22.10.0)