### PR TITLE
nginx-docker-compose.yml: remove the "version" field

### DIFF
--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -1,9 +1,7 @@
-version: "3.2"
-
 services:
   nginx:
     # https://github.com/macbre/docker-nginx-http3#quic--http3-support
-    image: ghcr.io/macbre/nginx-http3:1.27.0
+    image: ghcr.io/macbre/nginx-http3:1.29.3
     ports:
       - "8888:80"
       - "8889:443" # for old HTTP/1.1 with old TLS

--- a/test/nginx-docker-compose.yaml
+++ b/test/nginx-docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   nginx:
     # https://github.com/macbre/docker-nginx-http3#quic--http3-support
-    image: ghcr.io/macbre/nginx-http3:1.29.3
+    image: ghcr.io/macbre/nginx-http3:1.27.0
     ports:
       - "8888:80"
       - "8889:443" # for old HTTP/1.1 with old TLS


### PR DESCRIPTION
Remove the `version` field from the `nginx-docker-compose.yml` file.